### PR TITLE
feat: add calendar sync and role security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5433/locker"
+NEXTAUTH_SECRET="change-me"
+NEXTAUTH_URL="http://localhost:3000"
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+CRON_SECRET="set-a-random-cron-secret"
+WEBHOOK_CHANNEL_TOKEN="super-secret-channel-token"

--- a/README.md
+++ b/README.md
@@ -1,36 +1,83 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Locker
 
-## Getting Started
+Locker is a Next.js 15 dashboard for collegiate student-athletes. It ships with Google Calendar two-way sync, public iCal ingestion, and coach vs athlete role-aware experiences backed by PostgreSQL + Prisma, tRPC, and NextAuth v5.
 
-First, run the development server:
+## Getting started
+
+1. Install dependencies
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+2. Launch Postgres locally (or use the provided Docker compose file)
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+3. Apply the Prisma schema and seed demo data
 
-## Learn More
+```bash
+pnpm prisma db push
+pnpm run db:seed
+```
 
-To learn more about Next.js, take a look at the following resources:
+4. Start the dev server
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+pnpm dev
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+The dashboard is available at [http://localhost:3000](http://localhost:3000).
 
-## Deploy on Vercel
+## Environment variables
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Copy `.env.example` to `.env.local` and populate the secrets before running locally or deploying to Vercel.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+| Key | Description |
+| --- | --- |
+| `DATABASE_URL` | PostgreSQL connection string |
+| `NEXTAUTH_SECRET` | Secret for NextAuth JWT/session encryption |
+| `NEXTAUTH_URL` | Public base URL (used for Google Calendar webhooks) |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | OAuth client created in Google Cloud Console |
+| `CRON_SECRET` | Shared secret for background cron jobs |
+| `WEBHOOK_CHANNEL_TOKEN` | Token used to validate Google Calendar push notifications |
+
+## Calendar & Roles
+
+Locker keeps an internal `CalendarEvent` table that normalizes Google and iCal data so we can extend to Outlook or other providers in the future.
+
+### Google Calendar two-way sync
+
+- Athletes connect via **Account → Calendars → Connect Google Calendar**. Tokens are stored in the `GoogleCalendarToken` table.
+- The backend uses Google sync tokens plus push notifications (`/api/calendar/webhook`) to avoid polling; a 15 minute cron can call `revokeExpiredWatchChannels` with the `CRON_SECRET` if a webhook fails.
+- Coaches can create a single practice in `/api/calendar/create` and Locker fans it out into every athlete’s primary calendar.
+- `/api/calendar/list` serves normalized, internal event IDs—no raw Google IDs leak to the UI.
+
+### iCal ingestion
+
+- Athletes paste any public `.ics` feed in **Account → Calendars** and Locker uses `node-ical` to parse recurring rules, timezones, and exclusions.
+- Imports are idempotent (`uid + dtStart` unique constraint) and we show a summary of adds/updates/errors after every run.
+
+### Role based access & RLS
+
+- Users carry a `role` (`ATHLETE` or `COACH`) and `teamId` on the `User` table.
+- Middleware injects `x-locker-*` headers and guards `/coach/*` routes from athletes.
+- PostgreSQL row level security is enabled for `CalendarEvent` and `GoogleCalendarToken`. Each request sets session variables through Prisma helpers so leaked tokens can’t access another athlete’s data.
+- tRPC exposes dedicated `athleteProcedure` and `coachProcedure` helpers and the seed script provisions one coach plus three demo athletes on the same team.
+
+## Testing
+
+```bash
+pnpm test      # vitest unit + integration tests
+pnpm run tsc   # type-check under strict mode
+```
+
+Tests mock Google APIs with MSW-style handlers and cover the node-ical importer. Add new suites under `tests/`.
+
+## Deploying to Vercel
+
+- Set the environment variables above in the Vercel dashboard.
+- Configure the Google OAuth consent screen with the Vercel domain and webhook endpoint.
+- Point your scheduled cron (or Vercel Cron Job) to `revokeExpiredWatchChannels` with the shared `CRON_SECRET` to refresh watch channels every 12 hours.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: locker
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+
+import { auth } from "./src/auth"
+
+export default auth(async function middleware(req: NextRequest) {
+  const session = req.auth
+  const url = req.nextUrl
+
+  if (!session?.user?.id) {
+    if (url.pathname === "/api/calendar/webhook") {
+      return NextResponse.next()
+    }
+
+    if (url.pathname.startsWith("/api")) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const signInUrl = new URL("/api/auth/signin", req.url)
+    signInUrl.searchParams.set("callbackUrl", req.url)
+    return NextResponse.redirect(signInUrl)
+  }
+
+  if (url.pathname.startsWith("/coach") && session.user.role !== "COACH") {
+    return NextResponse.redirect(new URL("/", req.url))
+  }
+
+  const requestHeaders = new Headers(req.headers)
+  requestHeaders.set("x-locker-user-id", session.user.id)
+  requestHeaders.set("x-locker-role", session.user.role ?? "ATHLETE")
+  requestHeaders.set("x-locker-team-id", session.user.teamId ?? "")
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+})
+
+export const config = {
+  matcher: ["/coach/:path*", "/api/:path*", "/account/:path*"],
+}

--- a/package.json
+++ b/package.json
@@ -6,23 +6,37 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest",
+    "tsc": "tsc --noEmit",
+    "db:seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^1.5.3",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@trpc/client": "^11.0.0-next-beta.372",
+    "@trpc/react-query": "^11.0.0-next-beta.372",
+    "@trpc/server": "^11.0.0-next-beta.372",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
+    "googleapis": "^140.0.0",
     "lucide-react": "^0.544.0",
     "next": "15.5.4",
+    "next-auth": "^5.0.0-beta.25",
+    "node-ical": "^0.15.1",
+    "superjson": "^2.2.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8",
+    "@prisma/client": "^5.22.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -33,9 +47,13 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
+    "msw": "^2.6.6",
     "postcss": "^8.5.6",
+    "prisma": "^5.22.0",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.19.2",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.1.6"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,127 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  ATHLETE
+  COACH
+}
+
+enum CalendarSource {
+  GOOGLE
+  ICAL
+  MANUAL
+}
+
+model Team {
+  id        String   @id @default(uuid())
+  name      String
+  users     User[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model User {
+  id            String             @id @default(uuid())
+  name          String?
+  email         String?            @unique
+  emailVerified DateTime?
+  image         String?
+  role          Role               @default(ATHLETE)
+  teamId        String?
+  team          Team?              @relation(fields: [teamId], references: [id])
+  hydrationScore Int               @default(0)
+  accounts      Account[]
+  sessions      Session[]
+  calendarTokens GoogleCalendarToken?
+  calendarEvents CalendarEvent[]
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
+}
+
+model Account {
+  userId                 String
+  type                   String
+  provider               String
+  providerAccountId      String
+  refresh_token          String?  @db.Text
+  access_token           String?  @db.Text
+  expires_at             Int?
+  token_type             String?
+  scope                  String?
+  id_token               String?  @db.Text
+  session_state          String?
+  refresh_token_expires_in Int?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([provider, providerAccountId])
+  @@index([userId])
+}
+
+model Session {
+  id           String   @id @default(uuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model GoogleCalendarToken {
+  id                String   @id @default(uuid())
+  userId            String
+  calendarId        String   @default("primary")
+  accessToken       String?  @db.Text
+  refreshToken      String?  @db.Text
+  expiryDate        DateTime?
+  syncToken         String?  @db.Text
+  watchChannelId    String?
+  watchResourceId   String?
+  watchExpiration   DateTime?
+  lastSyncedAt      DateTime?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, calendarId])
+}
+
+model CalendarEvent {
+  id          String          @id @default(uuid())
+  userId      String
+  title       String
+  description String?
+  location    String?
+  start       DateTime
+  """Normalized UTC end time"""
+  end         DateTime
+  source      CalendarSource
+  externalId  String?
+  uid         String?
+  dtStart     DateTime?
+  raw         Json?
+  lastUpdated DateTime        @default(now())
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, start])
+  @@unique([userId, externalId])
+  @@unique([userId, uid, dtStart])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,94 @@
+import { Role } from "@prisma/client"
+
+import { prisma } from "@/server/db/client"
+
+const TEAM_ID = "11111111-1111-1111-1111-111111111111"
+
+async function main() {
+  const team = await prisma.team.upsert({
+    where: { id: TEAM_ID },
+    update: { name: "Locker Demo Team" },
+    create: {
+      id: TEAM_ID,
+      name: "Locker Demo Team",
+    },
+  })
+
+  const coach = await prisma.user.upsert({
+    where: { email: "coach@locker.app" },
+    update: {
+      name: "Coach Casey",
+      role: Role.COACH,
+      teamId: team.id,
+    },
+    create: {
+      email: "coach@locker.app",
+      name: "Coach Casey",
+      role: Role.COACH,
+      teamId: team.id,
+    },
+  })
+
+  const athleteSeeds = [
+    { email: "athlete1@locker.app", name: "Alex Runner" },
+    { email: "athlete2@locker.app", name: "Bree Swimmer" },
+    { email: "athlete3@locker.app", name: "Cam Thrower" },
+  ]
+
+  await Promise.all(
+    athleteSeeds.map(seed =>
+      prisma.user.upsert({
+        where: { email: seed.email },
+        update: {
+          name: seed.name,
+          role: Role.ATHLETE,
+          teamId: team.id,
+        },
+        create: {
+          email: seed.email,
+          name: seed.name,
+          role: Role.ATHLETE,
+          teamId: team.id,
+        },
+      }),
+    ),
+  )
+
+  await prisma.$executeRawUnsafe(`ALTER TABLE "CalendarEvent" ENABLE ROW LEVEL SECURITY`)
+  await prisma.$executeRawUnsafe(`ALTER TABLE "GoogleCalendarToken" ENABLE ROW LEVEL SECURITY`)
+
+  await prisma.$executeRawUnsafe(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'calendar_events_rls') THEN
+        CREATE POLICY "calendar_events_rls" ON "CalendarEvent"
+          USING (
+            "userId" = current_setting('app.current_user_id', true)
+            OR current_setting('app.current_role', true) = 'COACH'
+          );
+      END IF;
+    END $$;
+  `)
+
+  await prisma.$executeRawUnsafe(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'calendar_tokens_rls') THEN
+        CREATE POLICY "calendar_tokens_rls" ON "GoogleCalendarToken"
+          USING (
+            "userId" = current_setting('app.current_user_id', true)
+            OR current_setting('app.current_role', true) = 'COACH'
+          );
+      END IF;
+    END $$;
+  `)
+
+  console.log("Seed complete", { coach: coach.email, athletes: athleteSeeds.length })
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(error => {
+    console.error(error)
+    return prisma.$disconnect().finally(() => process.exit(1))
+  })

--- a/src/app/academics/page.tsx
+++ b/src/app/academics/page.tsx
@@ -118,6 +118,25 @@ const extractCourseFromSummary = (summary: string) => {
   return summary || "Calendar"
 }
 
+type ScheduleMeeting = {
+  id: number
+  course: string
+  meetingDays: string[]
+  startTime: string
+  endTime: string
+  nextOccurrence?: string | null
+}
+
+const calendarSchedule: ScheduleMeeting[] = []
+
+const formatMeetingDays = (meetingDays: string[]) =>
+  meetingDays.length ? meetingDays.join(", ") : "TBD"
+
+const formatTimeRange = (startTime: string, endTime: string) => `${startTime} - ${endTime}`
+
+const formatNextOccurrence = (nextOccurrence?: string | null) =>
+  nextOccurrence ? new Date(nextOccurrence).toLocaleString() : "No upcoming session"
+
 const mergeIcsEvents = (rawEvents: RawIcsEvent[], existingItems: AcademicItem[]) => {
   const existingExternalIds = new Set(
     existingItems

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
+import { signIn } from "next-auth/react"
+import { format, formatDistanceToNow } from "date-fns"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -51,6 +53,23 @@ const mockStats = {
   mobilityMinutesThisWeek: 120
 }
 
+type HydratedEvent = {
+  id: string
+  title: string
+  description?: string | null
+  location?: string | null
+  start: string
+  end: string
+  source: "GOOGLE" | "ICAL" | "MANUAL"
+  lastUpdated: string
+}
+
+const sourceLabels: Record<HydratedEvent["source"], string> = {
+  GOOGLE: "Google",
+  ICAL: "iCal",
+  MANUAL: "Locker",
+}
+
 const mockHistory = {
   weeklyCheckIns: [
     { week: "Week 1", mental: 4.2, physical: 3.8 },
@@ -68,6 +87,13 @@ export default function Account() {
   const [isEditing, setIsEditing] = useState(false)
   const [profile, setProfile] = useState(mockProfile)
   const [editedProfile, setEditedProfile] = useState(mockProfile)
+  const [isSyncing, setIsSyncing] = useState(false)
+  const [events, setEvents] = useState<HydratedEvent[]>([])
+  const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null)
+  const [icalUrl, setIcalUrl] = useState("")
+  const [isImporting, setIsImporting] = useState(false)
+  const [importSummary, setImportSummary] = useState<{ added: number; updated: number; errors: string[] } | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
   const handleSave = () => {
     setProfile(editedProfile)
@@ -89,6 +115,61 @@ export default function Account() {
     const lbs = Math.round(kg * 2.205)
     return `${lbs} lbs`
   }
+
+  const refreshEvents = async () => {
+    setIsSyncing(true)
+    setError(null)
+    try {
+      const response = await fetch("/api/calendar/list")
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error ?? "Failed to load calendar")
+      }
+
+      setEvents((data.events ?? []) as HydratedEvent[])
+      setLastSyncedAt(data.lastSyncedAt ? new Date(data.lastSyncedAt) : null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to sync calendar")
+    } finally {
+      setIsSyncing(false)
+    }
+  }
+
+  useEffect(() => {
+    void refreshEvents()
+  }, [])
+
+  const handleIcalImport = async () => {
+    if (!icalUrl) return
+    setIsImporting(true)
+    setError(null)
+    try {
+      const response = await fetch("/api/ical/fetch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: icalUrl }),
+      })
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error ?? "Failed to import calendar")
+      }
+
+      setImportSummary(data as { added: number; updated: number; errors: string[] })
+      setIcalUrl("")
+      await refreshEvents()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to import iCal feed")
+    } finally {
+      setIsImporting(false)
+    }
+  }
+
+  const googleConnected = Boolean(lastSyncedAt)
+  const syncLabel = lastSyncedAt
+    ? `Last synced ${formatDistanceToNow(lastSyncedAt, { addSuffix: true })}`
+    : "Not yet synced"
 
   return (
     <div className="space-y-6">
@@ -164,6 +245,7 @@ export default function Account() {
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="stats">Statistics</TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
+          <TabsTrigger value="calendars">Calendars</TabsTrigger>
           <TabsTrigger value="settings">Settings</TabsTrigger>
         </TabsList>
 
@@ -315,6 +397,106 @@ export default function Account() {
               </CardContent>
             </Card>
           </div>
+        </TabsContent>
+
+        <TabsContent value="calendars" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Google Calendar Sync</CardTitle>
+              <p className="text-sm text-muted-foreground">{syncLabel}</p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  onClick={() => signIn("google", { callbackUrl: "/account" })}
+                  variant={googleConnected ? "outline" : "default"}
+                >
+                  <Calendar className="mr-2 h-4 w-4" />
+                  {googleConnected ? "Reconnect Google Calendar" : "Connect Google Calendar"}
+                </Button>
+                <Button onClick={() => void refreshEvents()} variant="outline" disabled={isSyncing}>
+                  {isSyncing ? "Syncing..." : "Re-sync now"}
+                </Button>
+              </div>
+              {error ? <p className="text-sm text-destructive">{error}</p> : null}
+              <div className="rounded-xl border border-border/50 bg-background/60 p-4 shadow-sm backdrop-blur">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h4 className="font-semibold">Upcoming events</h4>
+                    <p className="text-sm text-muted-foreground">
+                      {events.length ? `${events.length} synced events` : "No events synced yet"}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-4 space-y-3 max-h-72 overflow-y-auto pr-2">
+                  {events.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">Connect your calendar to start syncing.</p>
+                  ) : (
+                    events.slice(0, 10).map(event => {
+                      const start = new Date(event.start)
+                      const end = new Date(event.end)
+                      return (
+                        <div key={event.id} className="rounded-lg border border-border/40 bg-background/70 p-3">
+                          <div className="flex items-center justify-between gap-2">
+                            <div>
+                              <h5 className="font-medium">{event.title}</h5>
+                              <p className="text-xs text-muted-foreground">
+                                {format(start, "MMM d • h:mm a")} - {format(end, "h:mm a")}
+                              </p>
+                            </div>
+                            <Badge variant="outline">{sourceLabels[event.source]}</Badge>
+                          </div>
+                          {event.location ? (
+                            <p className="mt-1 text-xs text-muted-foreground">{event.location}</p>
+                          ) : null}
+                          {event.description ? (
+                            <p className="mt-1 text-xs text-muted-foreground line-clamp-2">{event.description}</p>
+                          ) : null}
+                        </div>
+                      )
+                    })
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Import external calendars</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Paste any public .ics URL (Canvas, Apple Calendar, etc.) and Locker will keep it in sync.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input
+                  placeholder="https://example.com/calendar.ics"
+                  value={icalUrl}
+                  onChange={(event) => setIcalUrl(event.target.value)}
+                  className="flex-1"
+                />
+                <Button onClick={() => void handleIcalImport()} disabled={isImporting || !icalUrl}>
+                  {isImporting ? "Importing..." : "Import"}
+                </Button>
+              </div>
+              {importSummary ? (
+                <div className="rounded-lg border border-border/40 bg-background/60 p-4 text-sm">
+                  <p className="font-medium">Import summary</p>
+                  <p className="text-muted-foreground">
+                    {importSummary.added} events added, {importSummary.updated} updated, {importSummary.errors.length} errors
+                  </p>
+                  {importSummary.errors.length ? (
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-muted-foreground">
+                      {importSummary.errors.map((item, index) => (
+                        <li key={`${item}-${index}`}>{item}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
         </TabsContent>
 
         <TabsContent value="stats" className="space-y-4">

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/auth"

--- a/src/app/api/calendar/create/route.ts
+++ b/src/app/api/calendar/create/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { auth } from "@/auth"
+import { createPracticeEvent } from "@/server/services/google-calendar"
+
+const payloadSchema = z.object({
+  title: z.string().min(1),
+  start: z.coerce.date(),
+  end: z.coerce.date(),
+  athleteIds: z.array(z.string().uuid()).optional(),
+})
+
+export async function POST(req: Request) {
+  const session = await auth()
+
+  if (!session?.user?.id || session.user.role !== "COACH") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const json = await req.json()
+  const body = payloadSchema.parse(json)
+
+  if (body.end <= body.start) {
+    return NextResponse.json({ error: "End must be after start" }, { status: 400 })
+  }
+
+  await createPracticeEvent({
+    coachId: session.user.id,
+    title: body.title,
+    start: body.start,
+    end: body.end,
+    athleteIds: body.athleteIds,
+  })
+
+  return NextResponse.json({ status: "ok" })
+}

--- a/src/app/api/calendar/list/route.ts
+++ b/src/app/api/calendar/list/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+
+import { auth } from "@/auth"
+import { listHydratedEvents, syncGoogleCalendarForUser } from "@/server/services/google-calendar"
+
+export async function GET() {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  await syncGoogleCalendarForUser(session.user.id).catch(error => {
+    console.error("Failed to sync calendar", error)
+  })
+
+  const payload = await listHydratedEvents({
+    userId: session.user.id,
+    role: session.user.role ?? "ATHLETE",
+    teamId: session.user.teamId ?? null,
+  })
+  return NextResponse.json(payload)
+}

--- a/src/app/api/calendar/webhook/route.ts
+++ b/src/app/api/calendar/webhook/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+
+import { withSystemAccess } from "@/server/db/rls"
+import { handleCalendarWebhook } from "@/server/services/google-calendar"
+
+export async function POST(req: Request) {
+  const channelToken = req.headers.get("x-goog-channel-token") ?? undefined
+  const channelId = req.headers.get("x-goog-channel-id")
+  const resourceId = req.headers.get("x-goog-resource-id")
+
+  if (!channelId || !resourceId) {
+    return NextResponse.json({ error: "Missing headers" }, { status: 400 })
+  }
+
+  const tokens = await withSystemAccess(tx =>
+    tx.googleCalendarToken.findMany({
+      where: {
+        watchChannelId: channelId,
+      },
+    }),
+  )
+
+  await Promise.all(
+    tokens.map(token =>
+      handleCalendarWebhook({
+        channelId,
+        channelToken,
+        resourceId,
+        userId: token.userId,
+      }).catch(error => {
+        console.error("Webhook handling failed", error)
+      }),
+    ),
+  )
+
+  return NextResponse.json({ status: "ok" })
+}
+
+export async function GET() {
+  return NextResponse.json({ status: "ok" })
+}

--- a/src/app/api/ical/fetch/route.ts
+++ b/src/app/api/ical/fetch/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { auth } from "@/auth"
+import { importIcsForUser } from "@/server/services/ical"
+
+const schema = z.object({
+  url: z.string().url(),
+})
+
+export async function POST(req: Request) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const body = schema.parse(await req.json())
+  const result = await importIcsForUser(session.user.id, body.url)
+  return NextResponse.json(result)
+}

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,14 @@
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch"
+
+import { createTRPCContext } from "@/server/trpc/context"
+import { appRouter } from "@/server/trpc/router"
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: "/api/trpc",
+    req,
+    router: appRouter,
+    createContext: ({ req }) => createTRPCContext({ req }),
+  })
+
+export { handler as GET, handler as POST }

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,0 +1,47 @@
+import Google from "next-auth/providers/google"
+import type { NextAuthConfig } from "next-auth"
+import { PrismaAdapter } from "@auth/prisma-adapter"
+
+import { prisma } from "@/server/db/client"
+import { persistGoogleTokens } from "@/server/services/google-calendar"
+
+export const authConfig: NextAuthConfig = {
+  adapter: PrismaAdapter(prisma),
+  session: {
+    strategy: "database",
+  },
+  providers: [
+    Google({
+      authorization: {
+        params: {
+          scope:
+            "openid email profile https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events",
+          access_type: "offline",
+          prompt: "consent",
+        },
+      },
+    }),
+  ],
+  callbacks: {
+    async session({ session, user }) {
+      if (session.user) {
+        session.user.id = user.id
+        session.user.role = user.role
+        session.user.teamId = user.teamId
+      }
+      return session
+    },
+  },
+  events: {
+    async linkAccount({ user, account }) {
+      if (account.provider === "google") {
+        await persistGoogleTokens({
+          userId: user.id,
+          accessToken: account.access_token ?? undefined,
+          refreshToken: account.refresh_token ?? undefined,
+          expiresAt: account.expires_at ?? undefined,
+        })
+      }
+    },
+  },
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,30 @@
+import NextAuth from "next-auth"
+
+import { authConfig } from "./auth.config"
+
+declare module "next-auth" {
+  interface Session {
+    user?: {
+      id: string
+      name?: string | null
+      email?: string | null
+      image?: string | null
+      role?: import("@prisma/client").Role
+      teamId?: string | null
+    }
+  }
+
+  interface User {
+    role: import("@prisma/client").Role
+    teamId: string | null
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: import("@prisma/client").Role
+    teamId?: string | null
+  }
+}
+
+export const { auth, handlers: { GET, POST }, signIn, signOut } = NextAuth(authConfig)

--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client"
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+  })
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma
+}

--- a/src/server/db/rls.ts
+++ b/src/server/db/rls.ts
@@ -1,0 +1,38 @@
+import type { Prisma, PrismaClient } from "@prisma/client"
+
+import { prisma } from "./client"
+
+type Role = "ATHLETE" | "COACH"
+
+export interface RlsContext {
+  userId: string
+  role: Role
+  teamId: string | null
+}
+
+export async function withRls<T>(auth: RlsContext, fn: (tx: Prisma.TransactionClient) => Promise<T>) {
+  return prisma.$transaction(async tx => {
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_user_id', $1, true)`, auth.userId)
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_role', $1, true)`, auth.role)
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_team_id', $1, true)`, auth.teamId ?? "")
+
+    const result = await fn(tx)
+
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_user_id', '', true)`)
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_role', '', true)`)
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_team_id', '', true)`)
+
+    return result
+  })
+}
+
+export async function withSystemAccess<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>) {
+  return prisma.$transaction(async tx => {
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_role', 'COACH', true)`)
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_user_id', '', true)`)
+    const result = await fn(tx)
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_role', '', true)`)
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_user_id', '', true)`)
+    return result
+  })
+}

--- a/src/server/services/google-calendar.ts
+++ b/src/server/services/google-calendar.ts
@@ -1,0 +1,378 @@
+import { google } from "googleapis"
+import type { calendar_v3 } from "googleapis"
+import { addMinutes, subDays } from "date-fns"
+
+import { prisma } from "@/server/db/client"
+import { withRls, withSystemAccess } from "@/server/db/rls"
+import type { CalendarEvent, GoogleCalendarToken } from "@prisma/client"
+
+export interface PersistGoogleTokensInput {
+  userId: string
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: number
+}
+
+export async function persistGoogleTokens({
+  userId,
+  accessToken,
+  refreshToken,
+  expiresAt,
+}: PersistGoogleTokensInput): Promise<GoogleCalendarToken> {
+  const expiryDate = expiresAt ? new Date(expiresAt * 1000) : undefined
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true, teamId: true },
+  })
+
+  if (!user) {
+    throw new Error("User not found")
+  }
+
+  return withRls(
+    { userId, role: user.role, teamId: user.teamId },
+    tx =>
+      tx.googleCalendarToken.upsert({
+        where: {
+          userId_calendarId: { userId, calendarId: "primary" },
+        },
+        update: {
+          accessToken: accessToken ?? undefined,
+          refreshToken: refreshToken ?? undefined,
+          expiryDate,
+        },
+        create: {
+          userId,
+          accessToken,
+          refreshToken,
+          expiryDate,
+        },
+      }),
+  )
+}
+
+export async function getOAuthClient(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true, teamId: true },
+  })
+
+  if (!user) {
+    throw new Error("User not found")
+  }
+
+  const token = await withRls(
+    { userId, role: user.role, teamId: user.teamId },
+    tx =>
+      tx.googleCalendarToken.findUnique({
+        where: { userId_calendarId: { userId, calendarId: "primary" } },
+      }),
+  )
+
+  if (!token?.refreshToken) {
+    throw new Error("Missing Google refresh token")
+  }
+
+  const client = new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET,
+  )
+
+  client.setCredentials({
+    access_token: token.accessToken ?? undefined,
+    refresh_token: token.refreshToken,
+    expiry_date: token.expiryDate?.getTime(),
+  })
+
+  client.on("tokens", async next => {
+    await prisma.googleCalendarToken.update({
+      where: { id: token.id },
+      data: {
+        accessToken: next.access_token ?? token.accessToken,
+        expiryDate: next.expiry_date ? new Date(next.expiry_date) : token.expiryDate,
+      },
+    })
+  })
+
+  return { client, token, auth: { userId, role: user.role, teamId: user.teamId } }
+}
+
+const calendar = google.calendar("v3")
+
+export interface SyncOptions {
+  maxWindowDays?: number
+  forceFullSync?: boolean
+  webhookChannelToken?: string
+}
+
+export async function syncGoogleCalendarForUser(
+  userId: string,
+  options: SyncOptions = {},
+) {
+  const { client, token, auth } = await getOAuthClient(userId)
+  const maxWindowDays = options.maxWindowDays ?? 14
+  const now = new Date()
+  const timeMin = subDays(now, 1).toISOString()
+  const timeMax = addMinutes(now, maxWindowDays * 24 * 60).toISOString()
+
+  let pageToken: string | undefined
+  let syncToken = token.syncToken ?? undefined
+  const events: calendar_v3.Schema$Event[] = []
+
+  do {
+    const response = await calendar.events.list({
+      calendarId: "primary",
+      auth: client,
+      singleEvents: true,
+      orderBy: "startTime",
+      timeMin: syncToken && !options.forceFullSync ? undefined : timeMin,
+      timeMax: syncToken && !options.forceFullSync ? undefined : timeMax,
+      syncToken: syncToken && !options.forceFullSync ? syncToken : undefined,
+      pageToken,
+    })
+
+    if (!response.data.items) {
+      break
+    }
+
+    events.push(...response.data.items)
+    pageToken = response.data.nextPageToken ?? undefined
+    syncToken = response.data.nextSyncToken ?? syncToken
+  } while (pageToken)
+
+  await withRls(auth, async trx => {
+    for (const event of events) {
+      if (!event.id || !event.start?.dateTime || !event.end?.dateTime) continue
+
+      const start = new Date(event.start.dateTime)
+      const end = new Date(event.end.dateTime)
+
+      const payload: Partial<CalendarEvent> = {
+        title: event.summary ?? "Untitled Event",
+        description: event.description ?? undefined,
+        location: event.location ?? undefined,
+        start,
+        end,
+        source: "GOOGLE",
+        externalId: event.id,
+        raw: event as unknown as Record<string, unknown>,
+        lastUpdated: event.updated ? new Date(event.updated) : new Date(),
+      }
+
+      await trx.calendarEvent.upsert({
+        where: {
+          userId_externalId: {
+            userId,
+            externalId: event.id,
+          },
+        },
+        update: payload,
+        create: {
+          userId,
+          ...payload,
+        },
+      })
+    }
+
+    await trx.googleCalendarToken.update({
+      where: { id: token.id },
+      data: {
+        syncToken,
+        lastSyncedAt: new Date(),
+      },
+    })
+  })
+}
+
+export async function ensureWatchChannel(userId: string) {
+  const { client, token, auth } = await getOAuthClient(userId)
+  const channelId = token.watchChannelId ?? `locker-${token.id}`
+  const expiration = addMinutes(new Date(), 60 * 12)
+
+  const response = await calendar.events.watch({
+    calendarId: "primary",
+    auth: client,
+    requestBody: {
+      id: channelId,
+      type: "web_hook",
+      address: `${process.env.NEXTAUTH_URL}/api/calendar/webhook`,
+      token: process.env.WEBHOOK_CHANNEL_TOKEN,
+      params: { ttl: "43200" },
+    },
+  })
+
+  await withRls(auth, tx =>
+    tx.googleCalendarToken.update({
+      where: { id: token.id },
+      data: {
+        watchChannelId: channelId,
+        watchResourceId: response.data.resourceId ?? token.watchResourceId,
+        watchExpiration: expiration,
+      },
+    }),
+  )
+}
+
+export async function listHydratedEvents(auth: {
+  userId: string
+  role: "ATHLETE" | "COACH"
+  teamId: string | null
+}) {
+  return withRls(auth, async tx => {
+    const [events, token] = await Promise.all([
+      tx.calendarEvent.findMany({
+        where: { userId: auth.userId },
+        orderBy: { start: "asc" },
+      }),
+      tx.googleCalendarToken.findUnique({
+        where: { userId_calendarId: { userId: auth.userId, calendarId: "primary" } },
+        select: { lastSyncedAt: true },
+      }),
+    ])
+
+    return {
+      events: events.map(event => ({
+        id: event.id,
+        title: event.title,
+        description: event.description,
+        location: event.location,
+        start: event.start,
+        end: event.end,
+        source: event.source,
+        lastUpdated: event.lastUpdated,
+      })),
+      lastSyncedAt: token?.lastSyncedAt ?? null,
+    }
+  })
+}
+
+export interface CreatePracticeInput {
+  title: string
+  start: Date
+  end: Date
+  coachId: string
+  athleteIds?: string[]
+}
+
+export async function createPracticeEvent({
+  title,
+  start,
+  end,
+  coachId,
+  athleteIds,
+}: CreatePracticeInput) {
+  const coach = await prisma.user.findUniqueOrThrow({ where: { id: coachId } })
+
+  const athletes = await prisma.user.findMany({
+    where: {
+      role: "ATHLETE",
+      teamId: coach.teamId,
+      ...(athleteIds?.length ? { id: { in: athleteIds } } : {}),
+    },
+  })
+
+  await Promise.all(
+    athletes.map(async athlete => {
+      try {
+        const { client, auth: athleteAuth } = await getOAuthClient(athlete.id)
+
+        const event = await calendar.events.insert({
+          calendarId: "primary",
+          auth: client,
+          requestBody: {
+            summary: title,
+            start: { dateTime: start.toISOString() },
+            end: { dateTime: end.toISOString() },
+          },
+        })
+
+        if (event.data.id) {
+          await withRls(athleteAuth, tx =>
+            tx.calendarEvent.upsert({
+              where: {
+                userId_externalId: {
+                  userId: athlete.id,
+                  externalId: event.data.id!,
+                },
+              },
+              update: {
+                title,
+                start,
+                end,
+                source: "GOOGLE",
+                raw: event.data as unknown as Record<string, unknown>,
+              },
+              create: {
+                userId: athlete.id,
+                title,
+                start,
+                end,
+                source: "GOOGLE",
+                externalId: event.data.id!,
+                raw: event.data as unknown as Record<string, unknown>,
+              },
+            }),
+          )
+        }
+      } catch (error) {
+        console.error(`Failed to create event for athlete ${athlete.id}`, error)
+      }
+    }),
+  )
+}
+
+export interface WebhookPayload {
+  channelId: string
+  channelToken?: string
+  resourceId: string
+  userId: string
+}
+
+export async function handleCalendarWebhook({
+  channelId,
+  channelToken,
+  resourceId,
+  userId,
+}: WebhookPayload) {
+  if (channelToken !== process.env.WEBHOOK_CHANNEL_TOKEN) {
+    throw new Error("Invalid channel token")
+  }
+
+  const token = await withRls(
+    { userId, role: "ATHLETE", teamId: null },
+    tx =>
+      tx.googleCalendarToken.findFirst({
+        where: {
+          userId,
+          watchChannelId: channelId,
+          watchResourceId: resourceId,
+        },
+      }),
+  )
+
+  if (!token) {
+    throw new Error("Unknown watch channel")
+  }
+
+  await syncGoogleCalendarForUser(userId, { forceFullSync: false })
+}
+
+export async function revokeExpiredWatchChannels() {
+  const tokens = await withSystemAccess(tx =>
+    tx.googleCalendarToken.findMany({
+      where: {
+        watchExpiration: {
+          lt: addMinutes(new Date(), 5),
+        },
+      },
+    }),
+  )
+
+  for (const token of tokens) {
+    try {
+      await ensureWatchChannel(token.userId)
+    } catch (error) {
+      console.error("Failed to refresh watch channel", error)
+    }
+  }
+}

--- a/src/server/services/ical.ts
+++ b/src/server/services/ical.ts
@@ -1,0 +1,82 @@
+import ical from "node-ical"
+
+import { prisma } from "@/server/db/client"
+import { withRls } from "@/server/db/rls"
+
+export interface ImportIcsResult {
+  added: number
+  updated: number
+  errors: string[]
+}
+
+export async function importIcsForUser(userId: string, url: string): Promise<ImportIcsResult> {
+  const components = await ical.async.fromURL(url)
+  let added = 0
+  let updated = 0
+  const errors: string[] = []
+
+  const events = Object.values(components).filter(
+    (component): component is ical.VEvent => component.type === "VEVENT",
+  )
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true, teamId: true },
+  })
+
+  if (!user) {
+    throw new Error("User not found")
+  }
+
+  await withRls({ userId, role: user.role, teamId: user.teamId }, async tx => {
+    for (const event of events) {
+      try {
+        const start = event.start instanceof Date ? event.start : new Date(event.start as string)
+        const end = event.end instanceof Date ? event.end : new Date(event.end as string)
+
+        if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+          throw new Error(`Invalid start date for event ${event.uid}`)
+        }
+
+        const uid = event.uid ?? `${event.summary ?? "untitled"}-${start.getTime()}`
+
+        const payload = {
+          title: event.summary ?? "Untitled Event",
+          description: event.description ?? undefined,
+          location: event.location ?? undefined,
+          start,
+          end,
+          source: "ICAL" as const,
+          uid,
+          dtStart: start,
+          raw: event as unknown as Record<string, unknown>,
+        }
+
+        const result = await tx.calendarEvent.upsert({
+          where: {
+            userId_uid_dtStart: {
+              userId,
+              uid,
+              dtStart: payload.dtStart,
+            },
+          },
+          update: payload,
+          create: {
+            userId,
+            ...payload,
+          },
+        })
+
+        if (result.createdAt.getTime() === result.updatedAt.getTime()) {
+          added += 1
+        } else {
+          updated += 1
+        }
+      } catch (error) {
+        errors.push(error instanceof Error ? error.message : String(error))
+      }
+    }
+  })
+
+  return { added, updated, errors }
+}

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -1,0 +1,24 @@
+export interface AuthContext {
+  userId: string
+  role: "ATHLETE" | "COACH"
+  teamId: string | null
+}
+
+export async function createTRPCContext(opts: { req: Request }) {
+  const headers = opts.req.headers
+  const userId = headers.get("x-locker-user-id")
+  const role = (headers.get("x-locker-role") as AuthContext["role"]) ?? "ATHLETE"
+  const teamId = headers.get("x-locker-team-id")
+
+  if (!userId) {
+    throw new Error("Unauthorized")
+  }
+
+  const auth: AuthContext = {
+    userId,
+    role,
+    teamId: teamId || null,
+  }
+
+  return { auth }
+}

--- a/src/server/trpc/router.ts
+++ b/src/server/trpc/router.ts
@@ -1,0 +1,44 @@
+import { z } from "zod"
+
+import { prisma } from "@/server/db/client"
+import { listHydratedEvents } from "@/server/services/google-calendar"
+import { router, athleteProcedure, coachProcedure } from "./trpc"
+
+export const appRouter = router({
+  calendar: router({
+    list: athleteProcedure.query(async ({ ctx }) => {
+      return listHydratedEvents(ctx.auth)
+    }),
+  }),
+  coach: router({
+    teamHydration: coachProcedure
+      .input(z.object({ teamId: z.string().uuid().optional() }).optional())
+      .query(async ({ ctx, input }) => {
+        const teamId = input?.teamId ?? ctx.auth.teamId
+
+        if (!teamId) {
+          throw new Error("Coach must belong to a team to view hydration stats")
+        }
+
+        const hydration = await prisma.user.findMany({
+          where: {
+            teamId,
+            role: "ATHLETE",
+          },
+          select: {
+            id: true,
+            name: true,
+            hydrationScore: true,
+          },
+        })
+
+        return hydration.map(player => ({
+          id: player.id,
+          name: player.name,
+          hydrationScore: player.hydrationScore ?? 0,
+        }))
+      }),
+  }),
+})
+
+export type AppRouter = typeof appRouter

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -1,0 +1,32 @@
+import { initTRPC } from "@trpc/server"
+import superjson from "superjson"
+
+import type { AuthContext } from "./context"
+
+const t = initTRPC.context<{ auth: AuthContext }>().create({
+  transformer: superjson,
+  errorFormatter({ shape }) {
+    return shape
+  },
+})
+
+const isCoach = t.middleware(({ ctx, next }) => {
+  if (ctx.auth.role !== "COACH") {
+    throw new Error("Forbidden")
+  }
+
+  return next()
+})
+
+const isAthlete = t.middleware(({ ctx, next }) => {
+  if (!ctx.auth.userId) {
+    throw new Error("Unauthorized")
+  }
+
+  return next()
+})
+
+export const router = t.router
+export const publicProcedure = t.procedure
+export const athleteProcedure = t.procedure.use(isAthlete)
+export const coachProcedure = t.procedure.use(isCoach)

--- a/tests/google-calendar.test.ts
+++ b/tests/google-calendar.test.ts
@@ -1,0 +1,113 @@
+import { beforeAll, afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+const upsertMock = vi.fn()
+const updateMock = vi.fn()
+const findUniqueMock = vi.fn()
+const listTracker = vi.fn()
+
+class OAuth2Mock {
+  setCredentials() {}
+  on() {}
+}
+
+vi.mock("googleapis", () => ({
+  google: {
+    auth: {
+      OAuth2: OAuth2Mock,
+    },
+    calendar: () => ({
+      events: {
+        list: async () => {
+          listTracker()
+          const response = await fetch(
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+          )
+          const data = await response.json()
+          return { data }
+        },
+        insert: vi.fn(),
+        watch: vi.fn(),
+      },
+    }),
+  },
+}))
+
+vi.mock("../src/server/db/client", () => ({
+  prisma: {
+    user: {
+      findUnique: findUniqueMock,
+    },
+  },
+}))
+
+vi.mock("../src/server/db/rls", () => ({
+  withRls: vi.fn(async (_auth: unknown, fn: (tx: any) => any) =>
+    fn({
+      googleCalendarToken: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "token-1",
+          userId: "user-1",
+          calendarId: "primary",
+          refreshToken: "refresh-123",
+          accessToken: "access-123",
+          syncToken: null,
+        }),
+        update: updateMock,
+      },
+      calendarEvent: {
+        upsert: upsertMock,
+      },
+    } as any),
+  ),
+  withSystemAccess: vi.fn(async (fn: (tx: any) => any) => fn({
+    googleCalendarToken: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  } as any)),
+}))
+
+const { syncGoogleCalendarForUser } = await import("../src/server/services/google-calendar")
+
+const server = setupServer(
+  http.get("https://www.googleapis.com/calendar/v3/calendars/primary/events", () =>
+    HttpResponse.json({
+      items: [
+        {
+          id: "evt-1",
+          summary: "Practice",
+          start: { dateTime: "2024-01-01T10:00:00Z" },
+          end: { dateTime: "2024-01-01T11:00:00Z" },
+          updated: "2024-01-01T00:00:00Z",
+        },
+      ],
+      nextSyncToken: "sync-1",
+    }),
+  ),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  listTracker.mockReset()
+})
+afterAll(() => server.close())
+
+describe("syncGoogleCalendarForUser", () => {
+  beforeEach(() => {
+    upsertMock.mockReset()
+    updateMock.mockReset()
+    findUniqueMock.mockResolvedValue({ role: "ATHLETE", teamId: null })
+    upsertMock.mockResolvedValue({})
+    updateMock.mockResolvedValue({})
+  })
+
+  it("writes events and updates sync token", async () => {
+    await syncGoogleCalendarForUser("user-1")
+
+    expect(listTracker).toHaveBeenCalled()
+    expect(upsertMock).toHaveBeenCalled()
+    expect(updateMock).toHaveBeenCalled()
+  })
+})

--- a/tests/ical.test.ts
+++ b/tests/ical.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+import { importIcsForUser } from "../src/server/services/ical"
+
+const upsertMock = vi.fn()
+const findUniqueMock = vi.fn()
+
+vi.mock("node-ical", () => ({
+  default: {
+    async: {
+      fromURL: vi.fn(async () => ({
+        evt1: {
+          type: "VEVENT",
+          uid: "evt-1",
+          summary: "Workout",
+          start: new Date("2024-01-01T10:00:00Z"),
+          end: new Date("2024-01-01T11:00:00Z"),
+        },
+        evt2: {
+          type: "VEVENT",
+          uid: "evt-2",
+          summary: "Class",
+          start: new Date("2024-01-02T10:00:00Z"),
+          end: new Date("2024-01-02T11:00:00Z"),
+        },
+      })),
+    },
+  },
+}))
+
+vi.mock("../src/server/db/client", () => ({
+  prisma: {
+    user: {
+      findUnique: findUniqueMock,
+    },
+  },
+}))
+
+vi.mock("../src/server/db/rls", () => ({
+  withRls: vi.fn(async (_auth: unknown, fn: (tx: any) => any) =>
+    fn({
+      calendarEvent: {
+        upsert: upsertMock,
+      },
+    } as any),
+  ),
+}))
+
+describe("importIcsForUser", () => {
+  beforeEach(() => {
+    upsertMock.mockReset()
+    findUniqueMock.mockResolvedValue({ role: "ATHLETE", teamId: null })
+    upsertMock
+      .mockResolvedValueOnce({ createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01") })
+      .mockResolvedValueOnce({ createdAt: new Date("2024-01-02"), updatedAt: new Date("2024-02-02") })
+  })
+
+  it("tracks added and updated events", async () => {
+    const result = await importIcsForUser("user-1", "https://example.com/calendar.ics")
+
+    expect(result.added).toBe(1)
+    expect(result.updated).toBe(1)
+    expect(result.errors).toHaveLength(0)
+    expect(upsertMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    coverage: {
+      reporter: ["text", "lcov"],
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- integrate Google Calendar two-way sync with webhook handling, Prisma models, and role-scoped helpers
- add iCal ingestion pipeline, account UI for calendar connections, and role-aware middleware plus tRPC guardrails
- document calendar setup, seed data, environment variables, and add Vitest suites with msw plus docker compose for Postgres

## Testing
- `pnpm test` *(fails: vitest binary not present in current environment)*
- `pnpm run tsc` *(fails: missing installed dependencies and legacy mock dashboard code with implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d163ceec8323afee09e66e3930b9