### PR TITLE
feat: refresh interface with Yale blue palette

### DIFF
--- a/src/app/academics/page.tsx
+++ b/src/app/academics/page.tsx
@@ -244,12 +244,12 @@ const getTypeIcon = (type: string) => {
 
 const getTypeColor = (type: string) => {
   switch (type) {
-    case "exam": return "bg-red-100 text-red-800 border-red-200"
-    case "assignment": return "bg-blue-100 text-blue-800 border-blue-200"
-    case "reading": return "bg-green-100 text-green-800 border-green-200"
-    case "essay": return "bg-purple-100 text-purple-800 border-purple-200"
-    case "calendar": return "bg-amber-100 text-amber-800 border-amber-200"
-    default: return "bg-gray-100 text-gray-800 border-gray-200"
+    case "exam": return "bg-[#d9e3f5] text-[#0f4d92] border-[#b3c7e6]"
+    case "assignment": return "bg-[#e4f1ff] text-[#12467f] border-[#c5ddf5]"
+    case "reading": return "bg-[#edf2fa] text-[#123a70] border-[#c7d7ee]"
+    case "essay": return "bg-[#c7dbf3] text-[#0f2f5b] border-[#a8c2e5]"
+    case "calendar": return "bg-[#f2f6fb] text-[#1c4f8f] border-[#d7e3f5]"
+    default: return "bg-[#e8f0fb] text-[#123a70] border-[#c7d7ee]"
   }
 }
 
@@ -486,7 +486,7 @@ export default function Academics() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <BookOpen className="h-5 w-5 text-blue-600" />
+              <BookOpen className="h-5 w-5 text-[#0f4d92]" />
               <div>
                 <p className="text-sm font-medium">Total Items</p>
                 <p className="text-2xl font-bold">{academicItems.length}</p>
@@ -497,7 +497,7 @@ export default function Academics() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <AlertCircle className="h-5 w-5 text-red-600" />
+              <AlertCircle className="h-5 w-5 text-[#123d73]" />
               <div>
                 <p className="text-sm font-medium">Overdue</p>
                 <p className="text-2xl font-bold">{overdueItems.length}</p>
@@ -508,7 +508,7 @@ export default function Academics() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <CheckCircle className="h-5 w-5 text-green-600" />
+              <CheckCircle className="h-5 w-5 text-[#1c6dd0]" />
               <div>
                 <p className="text-sm font-medium">Completed</p>
                 <p className="text-2xl font-bold">
@@ -575,7 +575,7 @@ export default function Academics() {
                     <TableCell>
                       <div className="flex items-center gap-2">
                         <Calendar className="h-4 w-4 text-muted-foreground" />
-                        <span className={formatDate(item.dueAt) === "Overdue" ? "text-red-600" : ""}>
+                        <span className={formatDate(item.dueAt) === "Overdue" ? "text-[#123d73] font-semibold" : ""}>
                           {formatDate(item.dueAt)}
                         </span>
                       </div>
@@ -604,9 +604,9 @@ export default function Academics() {
 
       {/* Overdue Items Alert */}
       {overdueItems.length > 0 && (
-        <Card className="border-red-200 bg-red-50">
+        <Card className="border-[#b3c7e6] bg-[#eef5ff]">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-red-800">
+            <CardTitle className="flex items-center gap-2 text-[#0f4d92]">
               <AlertCircle className="h-5 w-5" />
               Overdue Items
             </CardTitle>
@@ -614,12 +614,12 @@ export default function Academics() {
           <CardContent>
             <div className="space-y-2">
               {overdueItems.map(item => (
-                <div key={item.id} className="flex items-center justify-between p-3 bg-white rounded-lg border border-red-200">
+                <div key={item.id} className="flex items-center justify-between p-3 bg-white rounded-lg border border-[#c7d7ee]">
                   <div>
                     <p className="font-medium">{item.title}</p>
                     <p className="text-sm text-muted-foreground">{item.course}</p>
                   </div>
-                  <Badge className="bg-red-100 text-red-800 border-red-200">
+                  <Badge className="bg-[#d9e3f5] text-[#0f2f5b] border-[#b3c7e6]">
                     Overdue
                   </Badge>
                 </div>

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -7,18 +7,15 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { 
-  User, 
-  Edit, 
-  Save, 
+import {
+  Edit,
+  Save,
   X,
   Calendar,
-  TrendingUp,
   Target,
   Award,
   Activity,
   Droplets,
-  Apple,
   BookOpen,
   Dumbbell,
   Settings,
@@ -240,7 +237,7 @@ export default function Account() {
                   <label className="text-sm font-medium">Allergies</label>
                   <div className="flex flex-wrap gap-2 mt-2">
                     {profile.allergies.map((allergy, index) => (
-                      <Badge key={index} variant="outline" className="bg-red-50 text-red-800 border-red-200">
+                      <Badge key={index} variant="outline" className="bg-[#eef5ff] text-[#0f2f5b] border-[#c7d7ee]">
                         {allergy}
                       </Badge>
                     ))}
@@ -333,7 +330,7 @@ export default function Account() {
             <Card>
               <CardContent className="p-4">
                 <div className="flex items-center space-x-2">
-                  <Dumbbell className="h-5 w-5 text-blue-600" />
+                  <Dumbbell className="h-5 w-5 text-[#0f4d92]" />
                   <div>
                     <p className="text-sm font-medium">Sessions This Month</p>
                     <p className="text-2xl font-bold">{mockStats.sessionsThisMonth}</p>
@@ -344,7 +341,7 @@ export default function Account() {
             <Card>
               <CardContent className="p-4">
                 <div className="flex items-center space-x-2">
-                  <Droplets className="h-5 w-5 text-green-600" />
+                  <Droplets className="h-5 w-5 text-[#1c6dd0]" />
                   <div>
                     <p className="text-sm font-medium">Hydration Average</p>
                     <p className="text-2xl font-bold">{mockStats.hydrationAverage}%</p>
@@ -355,7 +352,7 @@ export default function Account() {
             <Card>
               <CardContent className="p-4">
                 <div className="flex items-center space-x-2">
-                  <BookOpen className="h-5 w-5 text-purple-600" />
+                  <BookOpen className="h-5 w-5 text-[#123d73]" />
                   <div>
                     <p className="text-sm font-medium">Academic Items</p>
                     <p className="text-2xl font-bold">{mockStats.academicItemsCompleted}</p>
@@ -366,7 +363,7 @@ export default function Account() {
             <Card>
               <CardContent className="p-4">
                 <div className="flex items-center space-x-2">
-                  <Award className="h-5 w-5 text-yellow-600" />
+                  <Award className="h-5 w-5 text-[#0f2f5b]" />
                   <div>
                     <p className="text-sm font-medium">PRs This Month</p>
                     <p className="text-2xl font-bold">{mockStats.prsThisMonth}</p>
@@ -377,7 +374,7 @@ export default function Account() {
             <Card>
               <CardContent className="p-4">
                 <div className="flex items-center space-x-2">
-                  <Activity className="h-5 w-5 text-pink-600" />
+                  <Activity className="h-5 w-5 text-[#1c4f8f]" />
                   <div>
                     <p className="text-sm font-medium">Mobility Minutes</p>
                     <p className="text-2xl font-bold">{mockStats.mobilityMinutesThisWeek}</p>
@@ -430,15 +427,15 @@ export default function Account() {
                       <h3 className="font-semibold mb-3">{month.month}</h3>
                       <div className="grid grid-cols-3 gap-4 text-center">
                         <div>
-                          <p className="text-2xl font-bold text-blue-600">{month.sessions}</p>
+                          <p className="text-2xl font-bold text-[#0f4d92]">{month.sessions}</p>
                           <p className="text-xs text-muted-foreground">Sessions</p>
                         </div>
                         <div>
-                          <p className="text-2xl font-bold text-green-600">{month.hydration}%</p>
+                          <p className="text-2xl font-bold text-[#1c6dd0]">{month.hydration}%</p>
                           <p className="text-xs text-muted-foreground">Hydration</p>
                         </div>
                         <div>
-                          <p className="text-2xl font-bold text-purple-600">{month.academics}</p>
+                          <p className="text-2xl font-bold text-[#123d73]">{month.academics}</p>
                           <p className="text-xs text-muted-foreground">Academic Items</p>
                         </div>
                       </div>

--- a/src/app/fuel/page.tsx
+++ b/src/app/fuel/page.tsx
@@ -9,16 +9,14 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Progress } from "@/components/ui/progress"
-import { 
-  Apple, 
-  Plus, 
-  Droplets, 
+import {
+  Apple,
+  Plus,
+  Droplets,
   Coffee,
   GlassWater,
   Zap,
   Target,
-  TrendingUp,
-  Calendar,
   Clock
 } from "lucide-react"
 
@@ -82,11 +80,11 @@ const getMealTypeIcon = (type: string) => {
 
 const getMealTypeColor = (type: string) => {
   switch (type) {
-    case "breakfast": return "bg-orange-100 text-orange-800 border-orange-200"
-    case "lunch": return "bg-blue-100 text-blue-800 border-blue-200"
-    case "dinner": return "bg-purple-100 text-purple-800 border-purple-200"
-    case "snack": return "bg-green-100 text-green-800 border-green-200"
-    default: return "bg-gray-100 text-gray-800 border-gray-200"
+    case "breakfast": return "bg-[#f2f6fb] text-[#1c4f8f] border-[#d7e3f5]"
+    case "lunch": return "bg-[#d9e3f5] text-[#0f4d92] border-[#b3c7e6]"
+    case "dinner": return "bg-[#c7dbf3] text-[#0f2f5b] border-[#a8c2e5]"
+    case "snack": return "bg-[#e4f1ff] text-[#12467f] border-[#c5ddf5]"
+    default: return "bg-[#e8f0fb] text-[#123a70] border-[#c7d7ee]"
   }
 }
 
@@ -330,7 +328,7 @@ export default function Fuel() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Target className="h-5 w-5 text-green-600" />
+              <Target className="h-5 w-5 text-[#1c6dd0]" />
               <div>
                 <p className="text-sm font-medium">Hydration Goal</p>
                 <p className="text-2xl font-bold">{hydrationPercentage}%</p>
@@ -341,7 +339,7 @@ export default function Fuel() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Apple className="h-5 w-5 text-orange-600" />
+              <Apple className="h-5 w-5 text-[#0f4d92]" />
               <div>
                 <p className="text-sm font-medium">Calories Today</p>
                 <p className="text-2xl font-bold">{totalCalories}</p>
@@ -352,7 +350,7 @@ export default function Fuel() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Zap className="h-5 w-5 text-purple-600" />
+              <Zap className="h-5 w-5 text-[#123d73]" />
               <div>
                 <p className="text-sm font-medium">Protein Today</p>
                 <p className="text-2xl font-bold">{totalProtein}g</p>
@@ -590,22 +588,22 @@ export default function Fuel() {
         <CardContent>
           <div className="space-y-3">
             {hydrationPercentage < 70 && (
-              <div className="p-3 rounded-lg bg-yellow-50 border border-yellow-200">
-                <p className="text-sm text-yellow-800">
+              <div className="p-3 rounded-lg bg-[#eef5ff] border border-[#c7d7ee]">
+                <p className="text-sm text-[#0f2f5b]">
                   💧 You’re at {hydrationPercentage}% of your hydration goal. Consider drinking more water!
                 </p>
               </div>
             )}
             {totalProtein < 100 && (
-              <div className="p-3 rounded-lg bg-blue-50 border border-blue-200">
-                <p className="text-sm text-blue-800">
+              <div className="p-3 rounded-lg bg-[#e1ecfb] border border-[#b3c7e6]">
+                <p className="text-sm text-[#0f3a78]">
                   🥩 You’ve consumed {totalProtein}g protein today. Aim for 100-150g for optimal recovery.
                 </p>
               </div>
             )}
             {completedMeals < 3 && (
-              <div className="p-3 rounded-lg bg-green-50 border border-green-200">
-                <p className="text-sm text-green-800">
+              <div className="p-3 rounded-lg bg-[#dbe7f8] border border-[#b3c7e6]">
+                <p className="text-sm text-[#0f4d92]">
                   🍽️ You’ve completed {completedMeals} meals today. Don’t forget dinner!
                 </p>
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,56 +4,56 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --background: 213 60% 98%;
+    --foreground: 217 32% 12%;
+    --card: 213 60% 98%;
+    --card-foreground: 217 32% 12%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5.9% 10%;
+    --popover-foreground: 217 32% 12%;
+    --primary: 213 82% 32%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 213 72% 44%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 215 50% 92%;
+    --muted-foreground: 215 28% 34%;
+    --accent: 213 56% 70%;
+    --accent-foreground: 213 82% 28%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 214 36% 85%;
+    --input: 214 36% 85%;
+    --ring: 213 82% 32%;
     --radius: 0.75rem;
-    
+
     /* Premium gradients */
-    --gradient-primary: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    --gradient-secondary: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-    --gradient-success: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-    --gradient-warning: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-    --gradient-danger: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
-    --gradient-glass: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 100%);
+    --gradient-primary: linear-gradient(135deg, #0f4d92 0%, #1c6dd0 100%);
+    --gradient-secondary: linear-gradient(135deg, #1c6dd0 0%, #87a8d0 100%);
+    --gradient-success: linear-gradient(135deg, #2f855a 0%, #68d391 100%);
+    --gradient-warning: linear-gradient(135deg, #f6ad55 0%, #fbd38d 100%);
+    --gradient-danger: linear-gradient(135deg, #e53e3e 0%, #f56565 100%);
+    --gradient-glass: linear-gradient(135deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.08) 100%);
   }
 
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --background: 220 45% 8%;
+    --foreground: 213 36% 96%;
+    --card: 220 45% 10%;
+    --card-foreground: 213 36% 96%;
+    --popover: 220 45% 12%;
+    --popover-foreground: 213 36% 96%;
+    --primary: 213 82% 68%;
+    --primary-foreground: 220 45% 12%;
+    --secondary: 213 65% 26%;
+    --secondary-foreground: 213 36% 96%;
+    --muted: 220 40% 22%;
+    --muted-foreground: 213 36% 80%;
+    --accent: 213 65% 30%;
+    --accent-foreground: 213 36% 96%;
+    --destructive: 0 72% 40%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 220 40% 24%;
+    --input: 220 40% 24%;
+    --ring: 213 82% 68%;
   }
 }
 
@@ -62,7 +62,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 text-foreground antialiased;
+    @apply bg-gradient-to-br from-[#f0f4fa] via-[#d7e3f5] to-[#b7c8e5] text-foreground antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }
@@ -70,36 +70,36 @@
 @layer components {
   /* Premium glass morphism cards */
   .glass-card {
-    @apply bg-white/80 backdrop-blur-xl border border-white/20 shadow-xl;
+    @apply bg-white/85 backdrop-blur-xl border border-white/40 shadow-xl;
   }
-  
+
   .glass-card-dark {
-    @apply bg-gray-900/80 backdrop-blur-xl border border-gray-700/20 shadow-xl;
+    @apply bg-slate-900/80 backdrop-blur-xl border border-slate-700/30 shadow-xl;
   }
-  
+
   /* Premium gradients */
   .gradient-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #0f4d92 0%, #1c6dd0 100%);
   }
-  
+
   .gradient-secondary {
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+    background: linear-gradient(135deg, #1c6dd0 0%, #87a8d0 100%);
   }
-  
+
   .gradient-success {
-    background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+    background: linear-gradient(135deg, #2f855a 0%, #68d391 100%);
   }
-  
+
   .gradient-warning {
-    background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+    background: linear-gradient(135deg, #f6ad55 0%, #fbd38d 100%);
   }
-  
+
   .gradient-danger {
-    background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
+    background: linear-gradient(135deg, #e53e3e 0%, #f56565 100%);
   }
-  
+
   .gradient-hero {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+    background: linear-gradient(135deg, #0f4d92 0%, #1c6dd0 45%, #c7dbf3 100%);
   }
   
   /* Premium shadows */
@@ -112,7 +112,7 @@
   }
   
   .shadow-glow {
-    box-shadow: 0 0 20px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 0 20px rgba(15, 77, 146, 0.35);
   }
   
   /* Premium animations */

--- a/src/app/mobility/page.tsx
+++ b/src/app/mobility/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
@@ -14,10 +13,8 @@ import {
   Play, 
   Clock,
   Target,
-  Calendar,
   BookOpen,
   Zap,
-  Award,
   TrendingUp
 } from "lucide-react"
 
@@ -119,17 +116,6 @@ const getGroupIcon = (group: string) => {
   }
 }
 
-const getGroupColor = (group: string) => {
-  switch (group) {
-    case "back": return "bg-blue-100 text-blue-800 border-blue-200"
-    case "hips": return "bg-green-100 text-green-800 border-green-200"
-    case "hamstrings": return "bg-purple-100 text-purple-800 border-purple-200"
-    case "quads": return "bg-orange-100 text-orange-800 border-orange-200"
-    case "ankles": return "bg-pink-100 text-pink-800 border-pink-200"
-    default: return "bg-gray-100 text-gray-800 border-gray-200"
-  }
-}
-
 const exerciseGroups = [
   { name: "back", label: "Back", icon: "🫁" },
   { name: "hips", label: "Hips", icon: "🦴" },
@@ -144,7 +130,6 @@ export default function Mobility() {
   const [mobilityLogs, setMobilityLogs] = useState(mockMobilityLogs)
   const [isAddExerciseOpen, setIsAddExerciseOpen] = useState(false)
   const [isLogExerciseOpen, setIsLogExerciseOpen] = useState(false)
-  const [selectedExercise, setSelectedExercise] = useState<typeof exercises[0] | null>(null)
   const [newExercise, setNewExercise] = useState({
     group: "back",
     name: "",
@@ -188,7 +173,6 @@ export default function Mobility() {
   }
 
   const openLogDialog = (exercise: typeof exercises[0]) => {
-    setSelectedExercise(exercise)
     setNewLog(prev => ({ ...prev, exerciseId: exercise.id.toString() }))
     setIsLogExerciseOpen(true)
   }
@@ -350,7 +334,7 @@ export default function Mobility() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Clock className="h-5 w-5 text-green-600" />
+              <Clock className="h-5 w-5 text-[#1c6dd0]" />
               <div>
                 <p className="text-sm font-medium">This Week</p>
                 <p className="text-2xl font-bold">{totalMinutesThisWeek}m</p>
@@ -361,7 +345,7 @@ export default function Mobility() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Target className="h-5 w-5 text-blue-600" />
+              <Target className="h-5 w-5 text-[#0f4d92]" />
               <div>
                 <p className="text-sm font-medium">Exercises Done</p>
                 <p className="text-2xl font-bold">{uniqueExercisesThisWeek}</p>
@@ -372,7 +356,7 @@ export default function Mobility() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <TrendingUp className="h-5 w-5 text-purple-600" />
+              <TrendingUp className="h-5 w-5 text-[#123d73]" />
               <div>
                 <p className="text-sm font-medium">Avg Session</p>
                 <p className="text-2xl font-bold">8m</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,11 +154,23 @@ export default function DashboardPage() {
   const getPriorityBadge = (priority: string) => {
     switch (priority) {
       case "high":
-        return <Badge className="bg-gradient-to-r from-red-500 to-pink-500 text-white border-0 px-3 py-1">High</Badge>
+        return (
+          <Badge className="bg-gradient-to-r from-[#0f4d92] to-[#123d73] text-white border-0 px-3 py-1">
+            High
+          </Badge>
+        )
       case "medium":
-        return <Badge className="bg-gradient-to-r from-yellow-500 to-orange-500 text-white border-0 px-3 py-1">Medium</Badge>
+        return (
+          <Badge className="bg-gradient-to-r from-[#1c6dd0] to-[#2f7bdc] text-white border-0 px-3 py-1">
+            Medium
+          </Badge>
+        )
       case "low":
-        return <Badge className="bg-gradient-to-r from-green-500 to-emerald-500 text-white border-0 px-3 py-1">Low</Badge>
+        return (
+          <Badge className="bg-gradient-to-r from-[#87a8d0] to-[#c7dbf3] text-[#0f2f5b] border-0 px-3 py-1">
+            Low
+          </Badge>
+        )
       default:
         return <Badge variant="secondary">{priority}</Badge>
     }
@@ -167,11 +179,23 @@ export default function DashboardPage() {
   const getSessionIntensityBadge = (intensity: string) => {
     switch (intensity) {
       case "high":
-        return <Badge className="bg-gradient-to-r from-red-500 to-pink-500 text-white border-0 px-3 py-1">High</Badge>
+        return (
+          <Badge className="bg-gradient-to-r from-[#0f4d92] to-[#123d73] text-white border-0 px-3 py-1">
+            High
+          </Badge>
+        )
       case "medium":
-        return <Badge className="bg-gradient-to-r from-yellow-500 to-orange-500 text-white border-0 px-3 py-1">Medium</Badge>
+        return (
+          <Badge className="bg-gradient-to-r from-[#1c6dd0] to-[#2f7bdc] text-white border-0 px-3 py-1">
+            Medium
+          </Badge>
+        )
       case "low":
-        return <Badge className="bg-gradient-to-r from-green-500 to-emerald-500 text-white border-0 px-3 py-1">Low</Badge>
+        return (
+          <Badge className="bg-gradient-to-r from-[#87a8d0] to-[#c7dbf3] text-[#0f2f5b] border-0 px-3 py-1">
+            Low
+          </Badge>
+        )
       default:
         return <Badge variant="secondary">{intensity}</Badge>
     }
@@ -185,21 +209,21 @@ export default function DashboardPage() {
         {/* Hero Section */}
         <div className="mb-12">
           <div className="relative">
-            <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 via-purple-600/20 to-pink-600/20 rounded-3xl blur-3xl"></div>
+            <div className="absolute inset-0 bg-gradient-to-r from-[#0f4d92]/25 via-[#1c6dd0]/20 to-[#acc4e6]/25 rounded-3xl blur-3xl"></div>
             <div className="relative glass-card rounded-3xl p-8">
               <div className="flex items-center justify-between">
                 <div>
-                  <h1 className="text-4xl font-bold bg-gradient-to-r from-gray-900 via-blue-900 to-purple-900 bg-clip-text text-transparent mb-2">
+                  <h1 className="text-4xl font-bold bg-gradient-to-r from-[#0f172a] via-[#0f4d92] to-[#12284b] bg-clip-text text-transparent mb-2">
                     Good morning, Alex! 👋
                   </h1>
                   <p className="text-xl text-gray-600 font-medium">Ready to tackle another day?</p>
                   <div className="flex items-center mt-4 space-x-6">
                     <div className="flex items-center space-x-2">
-                      <div className="w-3 h-3 bg-green-400 rounded-full animate-pulse"></div>
+                      <div className="w-3 h-3 bg-[#0f4d92] rounded-full animate-pulse"></div>
                       <span className="text-sm text-gray-600 font-medium">All systems optimal</span>
                     </div>
                     <div className="flex items-center space-x-2">
-                      <Battery className="h-4 w-4 text-green-500" />
+                      <Battery className="h-4 w-4 text-[#1c6dd0]" />
                       <span className="text-sm text-gray-600 font-medium">87% energy</span>
                     </div>
                   </div>
@@ -223,7 +247,7 @@ export default function DashboardPage() {
               </div>
               Daily Check-in
               {checkInCompleted && (
-                <Badge className="bg-gradient-to-r from-green-500 to-emerald-500 text-white border-0 px-4 py-2">
+                <Badge className="bg-gradient-to-r from-[#0f4d92] to-[#123d73] text-white border-0 px-4 py-2">
                   <CheckCircle2 className="h-4 w-4 mr-2" />
                   Completed
                 </Badge>
@@ -283,7 +307,7 @@ export default function DashboardPage() {
                 <p className="text-sm font-semibold text-gray-600 mb-2">Strength</p>
                 <p className="text-3xl font-bold text-gray-900 mb-2">{mockData.performanceMetrics.strength}%</p>
                 <Progress value={mockData.performanceMetrics.strength} className="h-2" />
-                <p className="text-xs text-green-600 font-semibold mt-2">+5% this week</p>
+                <p className="text-xs text-[#1c6dd0] font-semibold mt-2">+5% this week</p>
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
@@ -294,7 +318,7 @@ export default function DashboardPage() {
                 <p className="text-sm font-semibold text-gray-600 mb-2">Endurance</p>
                 <p className="text-3xl font-bold text-gray-900 mb-2">{mockData.performanceMetrics.endurance}%</p>
                 <Progress value={mockData.performanceMetrics.endurance} className="h-2" />
-                <p className="text-xs text-green-600 font-semibold mt-2">+3% this week</p>
+                <p className="text-xs text-[#1c6dd0] font-semibold mt-2">+3% this week</p>
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
@@ -305,7 +329,7 @@ export default function DashboardPage() {
                 <p className="text-sm font-semibold text-gray-600 mb-2">Flexibility</p>
                 <p className="text-3xl font-bold text-gray-900 mb-2">{mockData.performanceMetrics.flexibility}%</p>
                 <Progress value={mockData.performanceMetrics.flexibility} className="h-2" />
-                <p className="text-xs text-yellow-600 font-semibold mt-2">Needs attention</p>
+                <p className="text-xs text-[#123d73] font-semibold mt-2">Needs attention</p>
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
@@ -316,7 +340,7 @@ export default function DashboardPage() {
                 <p className="text-sm font-semibold text-gray-600 mb-2">Mental</p>
                 <p className="text-3xl font-bold text-gray-900 mb-2">{mockData.performanceMetrics.mental}%</p>
                 <Progress value={mockData.performanceMetrics.mental} className="h-2" />
-                <p className="text-xs text-green-600 font-semibold mt-2">Excellent!</p>
+                <p className="text-xs text-[#1c6dd0] font-semibold mt-2">Excellent!</p>
               </CardContent>
             </Card>
           </div>
@@ -370,7 +394,7 @@ export default function DashboardPage() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12">
           <div className="space-y-6">
             <h3 className="text-2xl font-bold text-gray-900 flex items-center gap-3">
-              <Zap className="h-6 w-6 text-blue-600" />
+              <Zap className="h-6 w-6 text-[#0f4d92]" />
               Today&apos;s Progress
             </h3>
             
@@ -425,14 +449,14 @@ export default function DashboardPage() {
 
           <div className="lg:col-span-2 space-y-6">
             <h3 className="text-2xl font-bold text-gray-900 flex items-center gap-3">
-              <Calendar className="h-6 w-6 text-blue-600" />
+              <Calendar className="h-6 w-6 text-[#0f4d92]" />
               Upcoming
             </h3>
             
             <Card className="glass-card border-0 shadow-premium">
               <CardHeader className="pb-4">
                 <CardTitle className="text-xl text-gray-900 flex items-center gap-3">
-                  <BookOpen className="h-6 w-6 text-blue-600" />
+                  <BookOpen className="h-6 w-6 text-[#0f4d92]" />
                   Academics Due
                 </CardTitle>
               </CardHeader>
@@ -464,7 +488,7 @@ export default function DashboardPage() {
             <Card className="glass-card border-0 shadow-premium">
               <CardHeader className="pb-4">
                 <CardTitle className="text-xl text-gray-900 flex items-center gap-3">
-                  <Dumbbell className="h-6 w-6 text-blue-600" />
+                  <Dumbbell className="h-6 w-6 text-[#0f4d92]" />
                   Today&apos;s Training
                 </CardTitle>
               </CardHeader>
@@ -511,7 +535,7 @@ export default function DashboardPage() {
             <Card className="glass-card border-0 shadow-premium">
               <CardHeader className="pb-4">
                 <CardTitle className="text-xl text-gray-900 flex items-center gap-3">
-                  <Calendar className="h-6 w-6 text-blue-600" />
+                  <Calendar className="h-6 w-6 text-[#0f4d92]" />
                   Personal Calendar
                 </CardTitle>
               </CardHeader>
@@ -529,7 +553,7 @@ export default function DashboardPage() {
                         </p>
                         {event.focus && <p className="text-xs text-gray-500 mt-1">{event.focus}</p>}
                       </div>
-                      <Badge className="capitalize bg-white text-gray-700 border border-gray-200">{event.type}</Badge>
+                      <Badge className="capitalize bg-[#e8f0fb] text-[#123a70] border border-[#c7d7ee]">{event.type}</Badge>
                     </div>
                   ))
                 ) : (
@@ -542,7 +566,7 @@ export default function DashboardPage() {
             <Card className="glass-card border-0 shadow-premium">
               <CardHeader className="pb-4">
                 <CardTitle className="text-xl text-gray-900 flex items-center gap-3">
-                  <ListChecks className="h-6 w-6 text-blue-600" />
+                  <ListChecks className="h-6 w-6 text-[#0f4d92]" />
                   Workout Assignments
                 </CardTitle>
               </CardHeader>
@@ -566,8 +590,8 @@ export default function DashboardPage() {
                         className={cn(
                           "capitalize border-0 px-4 py-1",
                           workout.status === "Completed"
-                            ? "bg-emerald-500/90 text-white"
-                            : "bg-amber-200 text-amber-800"
+                            ? "bg-gradient-to-r from-[#0f4d92] to-[#123d73] text-white"
+                            : "bg-[#e2ebf9] text-[#0f2f5b]"
                         )}
                       >
                         {workout.status}
@@ -602,7 +626,7 @@ export default function DashboardPage() {
                 </div>
                 <p className="text-sm font-semibold text-gray-600 mb-2">Sessions</p>
                 <p className="text-4xl font-bold text-gray-900 mb-2">{mockData.weeklyStats.sessions}</p>
-                <p className="text-xs text-green-600 font-semibold">+2 from last week</p>
+                <p className="text-xs text-[#1c6dd0] font-semibold">+2 from last week</p>
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
@@ -612,7 +636,7 @@ export default function DashboardPage() {
                 </div>
                 <p className="text-sm font-semibold text-gray-600 mb-2">PRs Set</p>
                 <p className="text-4xl font-bold text-gray-900 mb-2">{mockData.weeklyStats.prsSet}</p>
-                <p className="text-xs text-green-600 font-semibold">New records!</p>
+                <p className="text-xs text-[#1c6dd0] font-semibold">New records!</p>
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
@@ -622,7 +646,7 @@ export default function DashboardPage() {
                 </div>
                 <p className="text-sm font-semibold text-gray-600 mb-2">Hydration Avg</p>
                 <p className="text-4xl font-bold text-gray-900 mb-2">{mockData.weeklyStats.hydrationAvg}%</p>
-                <p className="text-xs text-green-600 font-semibold">Good consistency</p>
+                <p className="text-xs text-[#1c6dd0] font-semibold">Good consistency</p>
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
@@ -632,7 +656,7 @@ export default function DashboardPage() {
                 </div>
                 <p className="text-sm font-semibold text-gray-600 mb-2">Assignments</p>
                 <p className="text-4xl font-bold text-gray-900 mb-2">{mockData.weeklyStats.assignments}</p>
-                <p className="text-xs text-green-600 font-semibold">5 completed</p>
+                <p className="text-xs text-[#1c6dd0] font-semibold">5 completed</p>
               </CardContent>
             </Card>
           </div>

--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -31,10 +31,10 @@ const mockPRs = [
 
 const getIntensityColor = (intensity: string) => {
   switch (intensity) {
-    case "high": return "bg-red-100 text-red-800 border-red-200"
-    case "medium": return "bg-yellow-100 text-yellow-800 border-yellow-200"
-    case "low": return "bg-green-100 text-green-800 border-green-200"
-    default: return "bg-gray-100 text-gray-800 border-gray-200"
+    case "high": return "bg-gradient-to-r from-[#0f4d92] to-[#123d73] text-white border-0"
+    case "medium": return "bg-[#1c6dd0] text-white border-[#1c6dd0]"
+    case "low": return "bg-[#e2ebf9] text-[#0f2f5b] border-[#b3c7e6]"
+    default: return "bg-[#e8f0fb] text-[#123a70] border-[#c7d7ee]"
   }
 }
 
@@ -328,7 +328,7 @@ export default function Training() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Award className="h-5 w-5 text-yellow-600" />
+              <Award className="h-5 w-5 text-[#0f2f5b]" />
               <div>
                 <p className="text-sm font-medium">PRs This Month</p>
                 <p className="text-2xl font-bold">{prs.length}</p>
@@ -339,7 +339,7 @@ export default function Training() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Timer className="h-5 w-5 text-green-600" />
+              <Timer className="h-5 w-5 text-[#1c6dd0]" />
               <div>
                 <p className="text-sm font-medium">Avg Session Time</p>
                 <p className="text-2xl font-bold">1.5h</p>
@@ -350,7 +350,7 @@ export default function Training() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Zap className="h-5 w-5 text-red-600" />
+              <Zap className="h-5 w-5 text-[#123d73]" />
               <div>
                 <p className="text-sm font-medium">High Intensity</p>
                 <p className="text-2xl font-bold">
@@ -456,7 +456,7 @@ export default function Training() {
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          <Badge className="bg-green-100 text-green-800 border-green-200">
+                          <Badge className="bg-gradient-to-r from-[#0f4d92] to-[#123d73] text-white border-0">
                             Completed
                           </Badge>
                         </TableCell>

--- a/src/components/coach-dashboard.tsx
+++ b/src/components/coach-dashboard.tsx
@@ -77,11 +77,11 @@ const isUpcoming = (value: string) => {
 const typeBadge = (type: string) => {
   switch (type) {
     case "lift":
-      return <Badge className="bg-purple-100 text-purple-700 border-purple-200">Strength</Badge>
+      return <Badge className="bg-[#d9e3f5] text-[#0f4d92] border-[#b3c7e6]">Strength</Badge>
     case "rehab":
-      return <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200">Recovery</Badge>
+      return <Badge className="bg-[#e4f1ff] text-[#12467f] border-[#c5ddf5]">Recovery</Badge>
     default:
-      return <Badge className="bg-blue-100 text-blue-700 border-blue-200">Practice</Badge>
+      return <Badge className="bg-[#edf2fa] text-[#123a70] border-[#c7d7ee]">Practice</Badge>
   }
 }
 
@@ -155,7 +155,7 @@ function CoachAthleteCard({
           <CardTitle className="text-xl text-gray-900">{name}</CardTitle>
           <p className="text-sm text-gray-500 font-medium">{sport} • {team}</p>
         </div>
-        <Badge className="bg-gradient-to-r from-indigo-500 to-purple-500 text-white border-0">{level}</Badge>
+        <Badge className="bg-gradient-to-r from-[#0f4d92] to-[#1c6dd0] text-white border-0">{level}</Badge>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="p-4 rounded-2xl bg-white/80 border border-white/60 shadow-sm">
@@ -180,7 +180,7 @@ function CoachAthleteCard({
 
         <div>
           <h4 className="text-sm font-semibold text-gray-900 mb-3 flex items-center gap-2">
-            <CalendarIcon className="h-4 w-4 text-indigo-500" /> Calendar Highlights
+            <CalendarIcon className="h-4 w-4 text-[#0f4d92]" /> Calendar Highlights
           </h4>
           <div className="space-y-2">
             {calendarHighlights.map((event) => (
@@ -202,7 +202,7 @@ function CoachAthleteCard({
 
         <div>
           <h4 className="text-sm font-semibold text-gray-900 mb-3 flex items-center gap-2">
-            <ListChecks className="h-4 w-4 text-emerald-500" /> Workout Plan
+            <ListChecks className="h-4 w-4 text-[#1c6dd0]" /> Workout Plan
           </h4>
           <div className="space-y-2">
             {activeWorkouts.map((workout) => (
@@ -217,8 +217,8 @@ function CoachAthleteCard({
                   className={cn(
                     "capitalize border-0",
                     workout.status === "Completed"
-                      ? "bg-emerald-500/90 text-white"
-                      : "bg-amber-200 text-amber-800"
+                      ? "bg-gradient-to-r from-[#0f4d92] to-[#123d73] text-white"
+                      : "bg-[#e2ebf9] text-[#0f2f5b]"
                   )}
                 >
                   {workout.status}
@@ -320,7 +320,7 @@ function CoachAthleteCard({
                   onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
                   placeholder="Key coaching points, equipment needs, etc."
                   rows={3}
-                  className="w-full rounded-md border border-gray-200 bg-white p-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  className="w-full rounded-md border border-gray-200 bg-white p-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c7dbf3]"
                 />
               </div>
             </div>
@@ -381,7 +381,7 @@ export function CoachDashboard() {
             Monitor athlete readiness, assign sessions, and keep calendars in sync.
           </p>
         </div>
-        <Badge className="bg-gradient-to-r from-blue-500 to-purple-500 text-white border-0">
+        <Badge className="bg-gradient-to-r from-[#0f4d92] to-[#1c6dd0] text-white border-0">
           <Users className="h-4 w-4 mr-2" /> {athletes.length} Athletes
         </Badge>
       </div>
@@ -394,7 +394,7 @@ export function CoachDashboard() {
                 <p className="text-xs uppercase tracking-wide text-gray-500">Team Sessions</p>
                 <p className="text-2xl font-bold text-gray-900">{totalSessions}</p>
               </div>
-              <Dumbbell className="h-8 w-8 text-indigo-500" />
+              <Dumbbell className="h-8 w-8 text-[#0f4d92]" />
             </div>
           </CardContent>
         </Card>
@@ -405,7 +405,7 @@ export function CoachDashboard() {
                 <p className="text-xs uppercase tracking-wide text-gray-500">Completion Rate</p>
                 <p className="text-2xl font-bold text-gray-900">{completionRate}%</p>
               </div>
-              <CheckCircle2 className="h-8 w-8 text-emerald-500" />
+              <CheckCircle2 className="h-8 w-8 text-[#1c6dd0]" />
             </div>
           </CardContent>
         </Card>
@@ -416,7 +416,7 @@ export function CoachDashboard() {
                 <p className="text-xs uppercase tracking-wide text-gray-500">Sessions Today</p>
                 <p className="text-2xl font-bold text-gray-900">{sessionsToday}</p>
               </div>
-              <Clock className="h-8 w-8 text-amber-500" />
+              <Clock className="h-8 w-8 text-[#87a8d0]" />
             </div>
           </CardContent>
         </Card>
@@ -427,7 +427,7 @@ export function CoachDashboard() {
                 <p className="text-xs uppercase tracking-wide text-gray-500">Open Assignments</p>
                 <p className="text-2xl font-bold text-gray-900">{upcomingAssignments}</p>
               </div>
-              <Target className="h-8 w-8 text-rose-500" />
+              <Target className="h-8 w-8 text-[#123d73]" />
             </div>
           </CardContent>
         </Card>
@@ -439,7 +439,7 @@ export function CoachDashboard() {
             <CardTitle className="text-xl text-gray-900">Upcoming Team Schedule</CardTitle>
             <p className="text-sm text-gray-500">Automated calendar view of all scheduled training blocks.</p>
           </div>
-          <Badge className="bg-blue-100 text-blue-600 border-blue-200">Next 5</Badge>
+          <Badge className="bg-[#edf2fa] text-[#123a70] border-[#c7d7ee]">Next 5</Badge>
         </CardHeader>
         <CardContent>
           <Table>
@@ -459,11 +459,11 @@ export function CoachDashboard() {
                     <TableCell>
                       <div className="flex items-center gap-2">
                         {session.type === "lift" ? (
-                          <Dumbbell className="h-4 w-4 text-purple-500" />
+                          <Dumbbell className="h-4 w-4 text-[#0f4d92]" />
                         ) : session.type === "rehab" ? (
-                          <Activity className="h-4 w-4 text-emerald-500" />
+                          <Activity className="h-4 w-4 text-[#1c6dd0]" />
                         ) : (
-                          <LineChart className="h-4 w-4 text-blue-500" />
+                          <LineChart className="h-4 w-4 text-[#123a70]" />
                         )}
                         <div>
                           <p className="font-semibold text-gray-900">{session.title}</p>
@@ -474,7 +474,7 @@ export function CoachDashboard() {
                     <TableCell className="text-sm text-gray-600">{athlete?.name ?? "Team"}</TableCell>
                     <TableCell className="text-sm text-gray-600">{formatDateTime(session.startAt)}</TableCell>
                     <TableCell>
-                      <Badge className="capitalize bg-white text-gray-700 border border-gray-200">
+                      <Badge className="capitalize bg-[#e8f0fb] text-[#0f2f5b] border border-[#c7d7ee]">
                         {session.intensity}
                       </Badge>
                     </TableCell>
@@ -495,7 +495,7 @@ export function CoachDashboard() {
 
       <div>
         <h2 className="text-2xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <Users className="h-5 w-5 text-indigo-500" /> Athlete Roster
+          <Users className="h-5 w-5 text-[#0f4d92]" /> Athlete Roster
         </h2>
         <div className="grid gap-4 lg:grid-cols-2">
           {athletes.map((athlete) => (

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -56,7 +56,7 @@ export function Navigation() {
                 <div className="w-12 h-12 rounded-2xl gradient-primary flex items-center justify-center shadow-glow animate-pulse-slow">
                   <Sparkles className="h-7 w-7 text-white" />
                 </div>
-                <div className="absolute -top-1 -right-1 w-4 h-4 bg-green-400 rounded-full border-2 border-white animate-pulse"></div>
+                <div className="absolute -top-1 -right-1 w-4 h-4 bg-[#0f4d92] rounded-full border-2 border-white animate-pulse"></div>
               </div>
               <div>
                 <h1 className="text-2xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">Locker</h1>
@@ -119,7 +119,7 @@ export function Navigation() {
                         "px-2 py-1 text-xs font-bold rounded-full",
                         pathname === item.href
                           ? "bg-white/20 text-white"
-                          : "bg-red-100 text-red-600"
+                          : "bg-[#e2ebf9] text-[#0f2f5b]"
                       )}>
                         {item.badge}
                       </span>
@@ -144,7 +144,7 @@ export function Navigation() {
                   <div className="w-12 h-12 rounded-2xl gradient-secondary flex items-center justify-center text-white font-bold text-lg shadow-lg">
                     AJ
                   </div>
-                  <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-green-400 rounded-full border-2 border-white"></div>
+                  <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-[#0f4d92] rounded-full border-2 border-white"></div>
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-bold text-gray-900">Alex Johnson</p>
@@ -152,11 +152,11 @@ export function Navigation() {
                     {role === "coach" ? "Head Coach" : "Track & Field • Elite"}
                   </p>
                   <div className="flex items-center mt-1">
-                    <TrendingUp className="h-3 w-3 text-green-500 mr-1" />
-                    <span className="text-xs text-green-600 font-semibold">+12% this week</span>
+                    <TrendingUp className="h-3 w-3 text-[#1c6dd0] mr-1" />
+                    <span className="text-xs text-[#1c6dd0] font-semibold">+12% this week</span>
                   </div>
                 </div>
-                <Zap className="h-4 w-4 text-yellow-500" />
+                <Zap className="h-4 w-4 text-[#123d73]" />
               </div>
             </div>
           </div>
@@ -242,7 +242,7 @@ export function Navigation() {
                               "px-2 py-1 text-xs font-bold rounded-full",
                               pathname === item.href
                                 ? "bg-white/20 text-white"
-                                : "bg-red-100 text-red-600"
+                                : "bg-[#e2ebf9] text-[#0f2f5b]"
                             )}>
                               {item.badge}
                             </span>

--- a/src/components/tile.tsx
+++ b/src/components/tile.tsx
@@ -21,10 +21,10 @@ export function Tile({ title, description, href, icon: Icon, className }: TilePr
               <Icon className="h-8 w-8 text-white" />
             </div>
             <div className="space-y-2">
-              <h3 className="text-xl font-bold text-gray-900 group-hover:text-blue-600 transition-colors">{title}</h3>
+              <h3 className="text-xl font-bold text-gray-900 group-hover:text-[#0f4d92] transition-colors">{title}</h3>
               <p className="text-gray-600 font-medium">{description}</p>
             </div>
-            <div className="w-full h-1 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+            <div className="w-full h-1 bg-gradient-to-r from-[#0f4d92] to-[#1c6dd0] rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- align global design tokens and gradients with a Yale blue inspired palette
- update dashboard pages and shared components to use the new palette for icons, badges, and highlights
- clean up unused imports to keep lint passing under the refreshed styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e719a4ebcc8323a7be630d595b316e