### PR TITLE
Add calories and fallback menus for Commons and Jonathan Edwards

### DIFF
--- a/src/app/api/yale-menu/route.ts
+++ b/src/app/api/yale-menu/route.ts
@@ -7,6 +7,7 @@ const USER_AGENT =
 type MenuItem = {
   name: string
   description?: string
+  calories?: number
 }
 
 type MenuMeal = {
@@ -26,37 +27,53 @@ const FALLBACK_MENU_ITEMS: MenuLocation[] = [
       {
         mealType: "Breakfast",
         items: [
-          { name: "Steel-cut oatmeal", description: "With dried fruit and brown sugar" },
-          { name: "Cage-free scrambled eggs" },
-          { name: "Greek yogurt parfait" }
+          { name: "Steel-cut oatmeal", description: "With dried fruit and brown sugar", calories: 220 },
+          { name: "Cage-free scrambled eggs", description: "Served with roasted tomatoes", calories: 180 },
+          { name: "Greek yogurt parfait", description: "Fresh berries and granola", calories: 260 }
         ]
       },
       {
         mealType: "Lunch",
         items: [
-          { name: "Lemon herb roasted chicken" },
-          { name: "Quinoa & vegetable pilaf" },
-          { name: "Roasted broccoli" }
+          { name: "Lemon herb roasted chicken", description: "With thyme pan sauce", calories: 420 },
+          { name: "Quinoa & vegetable pilaf", description: "Carrots, peas, and herbs", calories: 310 },
+          { name: "Roasted broccoli", description: "Garlic and olive oil", calories: 120 }
+        ]
+      },
+      {
+        mealType: "Dinner",
+        items: [
+          { name: "Grilled Atlantic salmon", description: "Citrus glaze and wild rice", calories: 480 },
+          { name: "Farro and roasted vegetables", description: "Sweet potatoes and kale", calories: 350 },
+          { name: "Seasonal fruit crisp", description: "Served warm with oats", calories: 260 }
         ]
       }
     ]
   },
   {
-    location: "Berkeley College",
+    location: "Jonathan Edwards College",
     meals: [
+      {
+        mealType: "Lunch",
+        items: [
+          { name: "Roasted turkey sandwich", description: "Cranberry aioli on multigrain", calories: 430 },
+          { name: "Butternut squash soup", description: "Toasted pepitas", calories: 210 },
+          { name: "Spinach and strawberry salad", description: "Poppy seed dressing", calories: 180 }
+        ]
+      },
       {
         mealType: "Dinner",
         items: [
-          { name: "Maple glazed salmon" },
-          { name: "Garlic mashed potatoes" },
-          { name: "Seasonal greens" }
+          { name: "Baked pesto pasta", description: "Mozzarella and cherry tomatoes", calories: 520 },
+          { name: "Citrus roasted carrots", description: "Orange glaze and parsley", calories: 160 },
+          { name: "Lemon olive oil cake", description: "With blueberry compote", calories: 340 }
         ]
       },
       {
         mealType: "Late Night",
         items: [
-          { name: "Grilled vegetable panini" },
-          { name: "Fresh fruit cups" }
+          { name: "Veggie hummus wrap", description: "Whole-wheat tortilla", calories: 290 },
+          { name: "Fresh fruit cups", description: "Seasonal selection", calories: 110 }
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- extend Yale menu menu item types with optional calorie data and surface it in the dining UI
- refresh the fallback response to include Commons and Jonathan Edwards sample menus complete with calorie information
- enhance the HTML parser so live data retains calories and shows them when adding meals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e742555e3c8323973c55de20323702