### PR TITLE
Fix dining menu filter fallback

### DIFF
--- a/src/app/fuel/page.tsx
+++ b/src/app/fuel/page.tsx
@@ -459,22 +459,25 @@ export default function Fuel() {
         }
       })
 
-      const filteredLocations = menuLocations
-        .map((location) => {
-          const normalized = normalizeLocationName(location.location)
-          const canonical = normalized ? knownLocationMap.get(normalized) : undefined
-          if (canonical && canonical !== location.location) {
-            return { ...location, location: canonical }
-          }
-          return location
-        })
-        .filter((location) => {
-          if (preferredLocationKeys.size === 0) return true
-          const normalized = normalizeLocationName(location.location)
-          return normalized ? preferredLocationKeys.has(normalized) : false
-        })
+      const canonicalizedLocations = menuLocations.map((location) => {
+        const normalized = normalizeLocationName(location.location)
+        const canonical = normalized ? knownLocationMap.get(normalized) : undefined
+        if (canonical && canonical !== location.location) {
+          return { ...location, location: canonical }
+        }
+        return location
+      })
 
-      return filteredLocations.sort((a, b) => a.location.localeCompare(b.location))
+      const filteredLocations = canonicalizedLocations.filter((location) => {
+        if (preferredLocationKeys.size === 0) return true
+        const normalized = normalizeLocationName(location.location)
+        return normalized ? preferredLocationKeys.has(normalized) : false
+      })
+
+      const locationsToReturn =
+        filteredLocations.length > 0 ? filteredLocations : canonicalizedLocations
+
+      return locationsToReturn.sort((a, b) => a.location.localeCompare(b.location))
     },
     [menuDateStrings]
   )


### PR DESCRIPTION
## Summary
- keep canonicalized dining locations separate from filtering so we do not discard valid results
- fall back to all parsed locations when preferred filters yield none so live menus render

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7469a235483238a8d08df595b9125