### PR TITLE
feat: add shared server state for accounts

### DIFF
--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { initialAthletes } from "@/lib/initial-data"
+import { normalizeAccounts, normalizeAthletes } from "@/lib/state-normalizer"
+import type { Athlete, StoredAccount } from "@/lib/role-types"
+
+type LockerServerState = {
+  accounts: StoredAccount[]
+  athletes: Athlete[]
+}
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T
+
+const globalForLocker = globalThis as typeof globalThis & {
+  __LOCKER_SERVER_STATE__?: LockerServerState
+}
+
+const getInitialState = (): LockerServerState => ({
+  accounts: [],
+  athletes: clone(initialAthletes),
+})
+
+const getServerState = (): LockerServerState => {
+  if (!globalForLocker.__LOCKER_SERVER_STATE__) {
+    globalForLocker.__LOCKER_SERVER_STATE__ = getInitialState()
+  }
+  return globalForLocker.__LOCKER_SERVER_STATE__
+}
+
+export async function GET() {
+  const state = getServerState()
+  return NextResponse.json({
+    accounts: clone(state.accounts),
+    athletes: clone(state.athletes),
+  })
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+  }
+
+  const payload = body as { accounts?: unknown; athletes?: unknown }
+  const current = getServerState()
+  const nextState: LockerServerState = {
+    accounts: current.accounts,
+    athletes: current.athletes,
+  }
+
+  if (Object.prototype.hasOwnProperty.call(payload, "accounts")) {
+    nextState.accounts = Array.isArray(payload.accounts)
+      ? normalizeAccounts(payload.accounts)
+      : current.accounts
+  }
+
+  if (Object.prototype.hasOwnProperty.call(payload, "athletes")) {
+    nextState.athletes = Array.isArray(payload.athletes)
+      ? normalizeAthletes(payload.athletes)
+      : current.athletes
+  }
+
+  globalForLocker.__LOCKER_SERVER_STATE__ = {
+    accounts: clone(nextState.accounts),
+    athletes: clone(nextState.athletes),
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/lib/initial-data.ts
+++ b/src/lib/initial-data.ts
@@ -1,0 +1,111 @@
+import type { Athlete, HydrationLog, MealLog } from "./role-types"
+
+export const initialHydrationLogs: HydrationLog[] = [
+  { id: 1, date: "2024-01-15", ounces: 8, source: "cup", time: "08:00" },
+  { id: 2, date: "2024-01-15", ounces: 12, source: "bottle", time: "10:30" },
+  { id: 3, date: "2024-01-15", ounces: 8, source: "cup", time: "12:00" },
+  { id: 4, date: "2024-01-15", ounces: 17, source: "shake", time: "14:00" },
+  { id: 5, date: "2024-01-15", ounces: 8, source: "cup", time: "16:30" },
+]
+
+export const initialMealLogs: MealLog[] = [
+  {
+    id: 1,
+    dateTime: "2024-01-15T08:00:00Z",
+    mealType: "breakfast",
+    calories: 450,
+    proteinG: 25,
+    notes: "Oatmeal with berries and protein powder",
+    completed: true,
+    nutritionFacts: [],
+  },
+  {
+    id: 2,
+    dateTime: "2024-01-15T12:30:00Z",
+    mealType: "lunch",
+    calories: 650,
+    proteinG: 40,
+    notes: "Grilled chicken salad",
+    completed: true,
+    nutritionFacts: [],
+  },
+  {
+    id: 3,
+    dateTime: "2024-01-15T18:00:00Z",
+    mealType: "dinner",
+    calories: 0,
+    proteinG: 0,
+    notes: "Planned: Salmon with quinoa",
+    completed: false,
+    nutritionFacts: [],
+  },
+  {
+    id: 4,
+    dateTime: "2024-01-15T15:00:00Z",
+    mealType: "snack",
+    calories: 200,
+    proteinG: 15,
+    notes: "Greek yogurt with nuts",
+    completed: true,
+    nutritionFacts: [],
+  },
+]
+
+export const initialAthletes: Athlete[] = [
+  {
+    id: 1,
+    name: "Alex Johnson",
+    email: "alex.johnson@locker.app",
+    sport: "Track & Field",
+    level: "Elite",
+    team: "Sprints",
+    tags: ["track", "sprints"],
+    sessions: [
+      {
+        id: 1,
+        type: "practice",
+        title: "Morning Practice",
+        startAt: "2024-01-15T06:00:00Z",
+        endAt: "2024-01-15T08:00:00Z",
+        intensity: "high",
+        notes: "Focus on technique",
+        completed: true,
+        assignedBy: "Coach Rivera",
+        focus: "Acceleration Drills",
+      },
+    ],
+    calendar: [
+      {
+        id: 1,
+        title: "Morning Practice",
+        date: "2024-01-15",
+        timeRange: "6:00 AM - 8:00 AM",
+        type: "practice",
+        focus: "Acceleration Drills",
+      },
+    ],
+    workouts: [
+      {
+        id: 1,
+        title: "Acceleration Drills",
+        focus: "Speed Mechanics",
+        dueDate: "2024-01-15",
+        status: "Completed",
+        intensity: "high",
+        assignedBy: "Coach Rivera",
+      },
+    ],
+    hydrationLogs: initialHydrationLogs,
+    mealLogs: initialMealLogs,
+    coachEmail: "coach.rivera@locker.app",
+    position: "Sprint Specialist",
+    heightCm: 175,
+    weightKg: 70,
+    allergies: ["Peanuts", "Shellfish"],
+    phone: "+1 (555) 123-4567",
+    location: "San Francisco, CA",
+    university: "University of California",
+    graduationYear: "2025",
+    isSeedData: true,
+  },
+]

--- a/src/lib/role-types.ts
+++ b/src/lib/role-types.ts
@@ -1,0 +1,96 @@
+export type Role = "athlete" | "coach"
+
+export type NutritionFact = {
+  name: string
+  amount?: number
+  unit?: string
+  percentDailyValue?: number
+  display?: string
+}
+
+export type HydrationLog = {
+  id: number
+  date: string
+  ounces: number
+  source: string
+  time: string
+}
+
+export type MealLog = {
+  id: number
+  dateTime: string
+  mealType: string
+  calories: number
+  proteinG: number
+  notes: string
+  completed: boolean
+  nutritionFacts: NutritionFact[]
+}
+
+export type Session = {
+  id: number
+  type: string
+  title: string
+  startAt: string
+  endAt: string
+  intensity: string
+  notes?: string
+  completed: boolean
+  assignedBy?: string
+  focus?: string
+}
+
+export type CalendarEvent = {
+  id: number
+  title: string
+  date: string
+  timeRange: string
+  type: string
+  focus?: string
+}
+
+export type WorkoutPlan = {
+  id: number
+  title: string
+  focus: string
+  dueDate: string
+  status: "Scheduled" | "Completed"
+  intensity: string
+  assignedBy?: string
+}
+
+export type Athlete = {
+  id: number
+  name: string
+  email: string
+  sport: string
+  level: string
+  team: string
+  tags: string[]
+  sessions: Session[]
+  calendar: CalendarEvent[]
+  workouts: WorkoutPlan[]
+  hydrationLogs: HydrationLog[]
+  mealLogs: MealLog[]
+  coachEmail?: string
+  position?: string
+  heightCm?: number
+  weightKg?: number
+  allergies?: string[]
+  phone?: string
+  location?: string
+  university?: string
+  graduationYear?: string
+  notes?: string
+  isSeedData?: boolean
+}
+
+export type StoredAccount = {
+  email: string
+  name: string
+  role: Role
+  password: string
+  athleteId?: number
+}
+
+export type UserAccount = Omit<StoredAccount, "password">

--- a/src/lib/state-normalizer.ts
+++ b/src/lib/state-normalizer.ts
@@ -1,0 +1,262 @@
+import type {
+  Athlete,
+  CalendarEvent,
+  HydrationLog,
+  MealLog,
+  NutritionFact,
+  Session,
+  StoredAccount,
+  WorkoutPlan,
+} from "./role-types"
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value)
+
+const isString = (value: unknown): value is string => typeof value === "string"
+
+export const normalizeTag = (tag: string) => tag.trim().toLowerCase()
+
+export const normalizeTags = (tags: unknown): string[] => {
+  if (!Array.isArray(tags)) return []
+  const normalized = tags
+    .map((tag) => (isString(tag) ? normalizeTag(tag) : ""))
+    .filter((tag) => tag.length > 0)
+  return Array.from(new Set(normalized))
+}
+
+const normalizeNutritionFacts = (facts: unknown): NutritionFact[] => {
+  if (!Array.isArray(facts)) return []
+  const normalized: NutritionFact[] = []
+  for (const fact of facts) {
+    if (!fact || typeof fact !== "object") continue
+    const record = fact as Record<string, unknown>
+    if (!isString(record.name) || !record.name.trim()) continue
+    const amount =
+      isFiniteNumber(record.amount) ? record.amount : undefined
+    const percentDailyValue =
+      isFiniteNumber(record.percentDailyValue) ? record.percentDailyValue : undefined
+    const unit = isString(record.unit) ? record.unit : undefined
+    const display = isString(record.display) ? record.display : undefined
+    normalized.push({
+      name: record.name.trim(),
+      amount,
+      unit,
+      percentDailyValue,
+      display,
+    })
+  }
+  return normalized
+}
+
+const normalizeHydrationLogs = (logs: unknown): HydrationLog[] => {
+  if (!Array.isArray(logs)) return []
+  const normalized: HydrationLog[] = []
+  for (const entry of logs) {
+    if (!entry || typeof entry !== "object") continue
+    const record = entry as Record<string, unknown>
+    if (!isFiniteNumber(record.id)) continue
+    if (!isString(record.date) || !isString(record.source) || !isString(record.time)) continue
+    const ounces = Number(record.ounces)
+    if (!Number.isFinite(ounces)) continue
+    normalized.push({
+      id: record.id,
+      date: record.date,
+      ounces,
+      source: record.source,
+      time: record.time,
+    })
+  }
+  return normalized
+}
+
+const normalizeMealLogs = (logs: unknown): MealLog[] => {
+  if (!Array.isArray(logs)) return []
+  const normalized: MealLog[] = []
+  for (const entry of logs) {
+    if (!entry || typeof entry !== "object") continue
+    const record = entry as Record<string, unknown>
+    if (!isFiniteNumber(record.id)) continue
+    if (!isString(record.dateTime) || !isString(record.mealType)) continue
+    const calories = Number(record.calories)
+    const proteinG = Number(record.proteinG)
+    if (!Number.isFinite(calories) || !Number.isFinite(proteinG)) continue
+    const notes = isString(record.notes) ? record.notes : ""
+    const completed = record.completed === true
+    normalized.push({
+      id: record.id,
+      dateTime: record.dateTime,
+      mealType: record.mealType,
+      calories,
+      proteinG,
+      notes,
+      completed,
+      nutritionFacts: normalizeNutritionFacts(record.nutritionFacts),
+    })
+  }
+  return normalized
+}
+
+const normalizeSessions = (sessions: unknown): Session[] => {
+  if (!Array.isArray(sessions)) return []
+  const normalized: Session[] = []
+  for (const session of sessions) {
+    if (!session || typeof session !== "object") continue
+    const record = session as Record<string, unknown>
+    if (!isFiniteNumber(record.id)) continue
+    if (!isString(record.type) || !isString(record.title)) continue
+    if (!isString(record.startAt) || !isString(record.endAt) || !isString(record.intensity)) continue
+    const notes = isString(record.notes) ? record.notes : undefined
+    const assignedBy = isString(record.assignedBy) ? record.assignedBy : undefined
+    const focus = isString(record.focus) ? record.focus : undefined
+    const completed = record.completed === true
+    normalized.push({
+      id: record.id,
+      type: record.type,
+      title: record.title,
+      startAt: record.startAt,
+      endAt: record.endAt,
+      intensity: record.intensity,
+      notes,
+      completed,
+      assignedBy,
+      focus,
+    })
+  }
+  return normalized
+}
+
+const normalizeCalendarEvents = (events: unknown): CalendarEvent[] => {
+  if (!Array.isArray(events)) return []
+  const normalized: CalendarEvent[] = []
+  for (const event of events) {
+    if (!event || typeof event !== "object") continue
+    const record = event as Record<string, unknown>
+    if (!isFiniteNumber(record.id)) continue
+    if (!isString(record.title) || !isString(record.date)) continue
+    if (!isString(record.timeRange) || !isString(record.type)) continue
+    const focus = isString(record.focus) ? record.focus : undefined
+    normalized.push({
+      id: record.id,
+      title: record.title,
+      date: record.date,
+      timeRange: record.timeRange,
+      type: record.type,
+      focus,
+    })
+  }
+  return normalized
+}
+
+const normalizeWorkouts = (workouts: unknown): WorkoutPlan[] => {
+  if (!Array.isArray(workouts)) return []
+  const normalized: WorkoutPlan[] = []
+  for (const workout of workouts) {
+    if (!workout || typeof workout !== "object") continue
+    const record = workout as Record<string, unknown>
+    if (!isFiniteNumber(record.id)) continue
+    if (!isString(record.title) || !isString(record.focus) || !isString(record.dueDate)) continue
+    if (!isString(record.status) || (record.status !== "Scheduled" && record.status !== "Completed")) continue
+    if (!isString(record.intensity)) continue
+    const assignedBy = isString(record.assignedBy) ? record.assignedBy : undefined
+    normalized.push({
+      id: record.id,
+      title: record.title,
+      focus: record.focus,
+      dueDate: record.dueDate,
+      status: record.status === "Completed" ? "Completed" : "Scheduled",
+      intensity: record.intensity,
+      assignedBy,
+    })
+  }
+  return normalized
+}
+
+const normalizeAthlete = (value: unknown): Athlete | null => {
+  if (!value || typeof value !== "object") return null
+  const record = value as Record<string, unknown>
+  if (!isFiniteNumber(record.id)) return null
+  if (!isString(record.email) || !record.email.trim()) return null
+  const email = record.email.trim().toLowerCase()
+  const name = isString(record.name) && record.name.trim() ? record.name.trim() : email
+  const sport = isString(record.sport) ? record.sport : ""
+  const level = isString(record.level) ? record.level : ""
+  const team = isString(record.team) ? record.team : ""
+  const position = isString(record.position) ? record.position : undefined
+  const coachEmail = isString(record.coachEmail) ? record.coachEmail : undefined
+  const location = isString(record.location) ? record.location : undefined
+  const university = isString(record.university) ? record.university : undefined
+  const graduationYear = isString(record.graduationYear) ? record.graduationYear : undefined
+  const phone = isString(record.phone) ? record.phone : undefined
+  const notes = isString(record.notes) ? record.notes : undefined
+  const heightCm = isFiniteNumber(record.heightCm) ? record.heightCm : undefined
+  const weightKg = isFiniteNumber(record.weightKg) ? record.weightKg : undefined
+  const allergies = Array.isArray(record.allergies)
+    ? record.allergies.filter(isString).map((item) => item.trim()).filter((item) => item.length > 0)
+    : undefined
+  const tags = normalizeTags(record.tags)
+  return {
+    id: record.id,
+    name,
+    email,
+    sport,
+    level,
+    team,
+    tags,
+    sessions: normalizeSessions(record.sessions),
+    calendar: normalizeCalendarEvents(record.calendar),
+    workouts: normalizeWorkouts(record.workouts),
+    hydrationLogs: normalizeHydrationLogs(record.hydrationLogs),
+    mealLogs: normalizeMealLogs(record.mealLogs),
+    coachEmail,
+    position,
+    heightCm,
+    weightKg,
+    allergies,
+    phone,
+    location,
+    university,
+    graduationYear,
+    notes,
+    isSeedData: record.isSeedData === true,
+  }
+}
+
+export const normalizeAthletes = (value: unknown): Athlete[] => {
+  if (!Array.isArray(value)) return []
+  const seen = new Set<number>()
+  const normalized: Athlete[] = []
+  for (const entry of value) {
+    const athlete = normalizeAthlete(entry)
+    if (!athlete) continue
+    if (seen.has(athlete.id)) continue
+    seen.add(athlete.id)
+    normalized.push(athlete)
+  }
+  return normalized
+}
+
+const ROLE_VALUES = new Set(["athlete", "coach"])
+
+export const normalizeAccounts = (value: unknown): StoredAccount[] => {
+  if (!Array.isArray(value)) return []
+  const map = new Map<string, StoredAccount>()
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue
+    const record = entry as Record<string, unknown>
+    if (!isString(record.email) || !record.email.trim()) continue
+    const email = record.email.trim().toLowerCase()
+    if (!isString(record.password) || !record.password) continue
+    if (!isString(record.role) || !ROLE_VALUES.has(record.role)) continue
+    const name = isString(record.name) && record.name.trim() ? record.name.trim() : email
+    const athleteId = isFiniteNumber(record.athleteId) ? record.athleteId : undefined
+    const key = `${email}:${record.role}`
+    map.set(key, {
+      email,
+      name,
+      role: record.role as StoredAccount["role"],
+      password: record.password,
+      athleteId,
+    })
+  }
+  return Array.from(map.values())
+}


### PR DESCRIPTION
## Summary
- extract shared role data types and seed data so both client and API can reuse them
- add a lightweight API route that stores sanitized account and athlete data for cross-device access
- update the role context to merge server data and sync changes back to the API while keeping local storage support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e96b1522008323beab95583470f77a