### PR TITLE
Add training video technique analyzer

### DIFF
--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -10,6 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useRole } from "@/components/role-context"
 import { CoachDashboard } from "@/components/coach-dashboard"
+import { VideoAnalyzer } from "@/components/training/video-analyzer"
 import {
   Dumbbell,
   Plus,
@@ -368,6 +369,8 @@ export default function Training() {
           </CardContent>
         </Card>
       </div>
+
+      <VideoAnalyzer />
 
       {/* Main Content */}
       <Tabs defaultValue="sessions" className="space-y-4">

--- a/src/components/training/video-analyzer.tsx
+++ b/src/components/training/video-analyzer.tsx
@@ -1,0 +1,633 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { AlertCircle, Loader2, PlayCircle, Video } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  NormalizedLandmark,
+  PoseAnalysis,
+  PoseMetricKey,
+  REFERENCE_CONNECTIONS,
+  accumulatePoseMetrics,
+  createPoseAccumulator,
+  finalizePoseMetrics,
+  formatDegrees,
+  formatRatio,
+} from "@/lib/pose-utils"
+import { ExampleMetricRange, ExerciseExample, exerciseExamples } from "@/data/exercise-examples"
+
+const VISION_BUNDLE_URL =
+  "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/vision_bundle.mjs"
+const VISION_WASM_URL = "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/wasm"
+const POSE_MODEL_URL =
+  "https://storage.googleapis.com/mediapipe-models/pose_landmarker/lite/pose_landmarker_lite.task"
+
+interface PoseLandmarkerInstance {
+  detectForVideo: (
+    video: HTMLVideoElement,
+    timestamp: number,
+  ) => { landmarks?: NormalizedLandmark[][] }
+  close: () => void
+}
+
+interface DrawingUtilsInstance {
+  drawLandmarks: (landmarks: NormalizedLandmark[], options?: Record<string, unknown>) => void
+  drawConnectors: (
+    landmarks: NormalizedLandmark[],
+    connections: Array<[number, number]>,
+    options?: Record<string, unknown>,
+  ) => void
+}
+
+interface VisionModule {
+  FilesetResolver: {
+    forVisionTasks: (path: string) => Promise<unknown>
+  }
+  PoseLandmarker: {
+    createFromOptions: (vision: unknown, options: Record<string, unknown>) => Promise<PoseLandmarkerInstance>
+    POSE_CONNECTIONS: Array<[number, number]>
+  }
+  DrawingUtils: new (ctx: CanvasRenderingContext2D) => DrawingUtilsInstance
+}
+
+type PoseComparisonStatus = "match" | "deviation" | "missing"
+
+interface PoseComparison {
+  metric: ExampleMetricRange
+  value: number | null
+  status: PoseComparisonStatus
+  delta: number | null
+}
+
+const formatMetricValue = (metric: ExampleMetricRange, value: number | null) => {
+  if (metric.unit === "ratio") {
+    return formatRatio(value)
+  }
+  return formatDegrees(value)
+}
+
+const describeDelta = (metric: ExampleMetricRange, delta: number | null) => {
+  if (delta === null || delta === 0) return "On target"
+  const direction = delta > 0 ? "higher" : "lower"
+  const magnitude = metric.unit === "ratio" ? Math.abs(delta).toFixed(3) : `${Math.abs(delta).toFixed(1)}°`
+  return `${magnitude} ${direction} than the reference window`
+}
+
+const drawReferenceSkeleton = (
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  landmarks: NormalizedLandmark[],
+) => {
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  ctx.lineWidth = 4
+  ctx.strokeStyle = "rgba(30, 64, 175, 0.9)"
+  ctx.fillStyle = "rgba(59, 130, 246, 0.95)"
+
+  const scaleX = canvas.width
+  const scaleY = canvas.height
+
+  REFERENCE_CONNECTIONS.forEach(([start, end]) => {
+    const a = landmarks[start]
+    const b = landmarks[end]
+    if (!a || !b) return
+    ctx.beginPath()
+    ctx.moveTo(a.x * scaleX, a.y * scaleY)
+    ctx.lineTo(b.x * scaleX, b.y * scaleY)
+    ctx.stroke()
+  })
+
+  landmarks.forEach((landmark) => {
+    if (!landmark) return
+    ctx.beginPath()
+    ctx.arc(landmark.x * scaleX, landmark.y * scaleY, 5, 0, Math.PI * 2)
+    ctx.fill()
+  })
+}
+
+const usePoseComparisons = (analysis: PoseAnalysis | null, exercise: ExerciseExample | null) =>
+  useMemo<PoseComparison[]>(() => {
+    if (!analysis || !exercise) return []
+
+    return exercise.metrics.map((metric) => {
+      const key = metric.key as PoseMetricKey
+      const value = analysis[key]
+      if (value === null || typeof value === "undefined") {
+        return { metric, value: null, status: "missing", delta: null }
+      }
+
+      const within = value >= metric.min && value <= metric.max
+      let delta = 0
+      if (!within) {
+        if (value < metric.min) {
+          delta = value - metric.min
+        } else if (value > metric.max) {
+          delta = value - metric.max
+        }
+      }
+
+      return {
+        metric,
+        value,
+        status: within ? "match" : "deviation",
+        delta: within ? 0 : delta,
+      }
+    })
+  }, [analysis, exercise])
+
+export function VideoAnalyzer() {
+  const [selectedExerciseId, setSelectedExerciseId] = useState(exerciseExamples[0]?.id ?? "")
+  const [uploadedVideoUrl, setUploadedVideoUrl] = useState<string | null>(null)
+  const [modelError, setModelError] = useState<string | null>(null)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [analysis, setAnalysis] = useState<PoseAnalysis | null>(null)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [isModelLoading, setIsModelLoading] = useState(false)
+
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+  const overlayRef = useRef<HTMLCanvasElement | null>(null)
+  const exampleCanvasRef = useRef<HTMLCanvasElement | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const poseLandmarkerRef = useRef<PoseLandmarkerInstance | null>(null)
+  const visionModuleRef = useRef<VisionModule | null>(null)
+  const animationFrameRef = useRef<number>()
+  const sampleTimestampRef = useRef<number>(0)
+  const exampleAnimationRef = useRef<number>()
+
+  const selectedExercise = useMemo(
+    () => exerciseExamples.find((example) => example.id === selectedExerciseId) ?? null,
+    [selectedExerciseId],
+  )
+
+  const comparisons = usePoseComparisons(analysis, selectedExercise)
+  const comparisonScore = useMemo(() => {
+    if (!comparisons.length) return null
+    const usable = comparisons.filter((comparison) => comparison.value !== null)
+    if (!usable.length) return null
+    const matches = usable.filter((comparison) => comparison.status === "match").length
+    return Math.round((matches / usable.length) * 100)
+  }, [comparisons])
+
+  const cleanupAnimation = useCallback(() => {
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current)
+      animationFrameRef.current = undefined
+    }
+  }, [])
+
+  const loadPoseLandmarker = useCallback(async () => {
+    if (poseLandmarkerRef.current || typeof window === "undefined") return
+
+    setIsModelLoading(true)
+    setModelError(null)
+
+    try {
+      const visionModule = (await import(
+        /* webpackIgnore: true */ VISION_BUNDLE_URL
+      )) as VisionModule
+      visionModuleRef.current = visionModule
+      const fileset = await visionModule.FilesetResolver.forVisionTasks(VISION_WASM_URL)
+      const landmarker = await visionModule.PoseLandmarker.createFromOptions(fileset, {
+        baseOptions: {
+          modelAssetPath: POSE_MODEL_URL,
+        },
+        runningMode: "VIDEO",
+        numPoses: 1,
+        minPoseDetectionConfidence: 0.4,
+        minPosePresenceConfidence: 0.4,
+        minTrackingConfidence: 0.5,
+      })
+
+      poseLandmarkerRef.current = landmarker
+    } catch (error) {
+      console.error(error)
+      setModelError(
+        "Unable to load the MediaPipe pose model. Check your connection and try again.",
+      )
+    } finally {
+      setIsModelLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadPoseLandmarker()
+    return () => {
+      cleanupAnimation()
+      if (poseLandmarkerRef.current) {
+        poseLandmarkerRef.current.close()
+        poseLandmarkerRef.current = null
+      }
+      if (uploadedVideoUrl) {
+        URL.revokeObjectURL(uploadedVideoUrl)
+      }
+      if (exampleAnimationRef.current) {
+        window.clearInterval(exampleAnimationRef.current)
+      }
+    }
+  }, [cleanupAnimation, loadPoseLandmarker, uploadedVideoUrl])
+
+  useEffect(() => {
+    const video = videoRef.current
+    const canvas = overlayRef.current
+    if (!video || !canvas) return
+
+    const handleMetadata = () => {
+      canvas.width = video.videoWidth
+      canvas.height = video.videoHeight
+    }
+
+    video.addEventListener("loadedmetadata", handleMetadata)
+    return () => {
+      video.removeEventListener("loadedmetadata", handleMetadata)
+    }
+  }, [])
+
+  useEffect(() => {
+    const canvas = exampleCanvasRef.current
+    if (!canvas || !selectedExercise) return
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    canvas.width = 480
+    canvas.height = 270
+
+    if (exampleAnimationRef.current) {
+      window.clearInterval(exampleAnimationRef.current)
+    }
+
+    let frameIndex = 0
+    const frames = selectedExercise.referenceFrames
+    const tick = () => {
+      const frame = frames[frameIndex]
+      if (frame) {
+        drawReferenceSkeleton(ctx, canvas, frame)
+      }
+      frameIndex = (frameIndex + 1) % frames.length
+    }
+
+    tick()
+    exampleAnimationRef.current = window.setInterval(tick, 350)
+
+    return () => {
+      if (exampleAnimationRef.current) {
+        window.clearInterval(exampleAnimationRef.current)
+        exampleAnimationRef.current = undefined
+      }
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+    }
+  }, [selectedExercise])
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    if (!file.type.startsWith("video/")) {
+      setUploadError("Please select a video file (mp4, mov, webm, etc.).")
+      setUploadedVideoUrl(null)
+      setAnalysis(null)
+      return
+    }
+
+    if (uploadedVideoUrl) {
+      URL.revokeObjectURL(uploadedVideoUrl)
+    }
+
+    const url = URL.createObjectURL(file)
+    setUploadedVideoUrl(url)
+    setUploadError(null)
+    setAnalysis(null)
+  }
+
+  const resetVideo = useCallback(() => {
+    if (videoRef.current) {
+      videoRef.current.pause()
+      videoRef.current.currentTime = 0
+    }
+    cleanupAnimation()
+  }, [cleanupAnimation])
+
+  const finalizeAnalysis = useCallback(
+    (accumulator = createPoseAccumulator()) => {
+      const summary = finalizePoseMetrics(accumulator)
+      setAnalysis(summary.frameCount > 0 ? summary : null)
+      setIsProcessing(false)
+    },
+    [],
+  )
+
+  const processVideo = useCallback(() => {
+    const landmarker = poseLandmarkerRef.current
+    const visionModule = visionModuleRef.current
+    const video = videoRef.current
+    const canvas = overlayRef.current
+
+    if (!landmarker || !visionModule || !video || !canvas) {
+      setModelError(
+        "Pose model is not ready yet. Wait for the model to finish loading and try again.",
+      )
+      return
+    }
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) {
+      setModelError("Unable to read drawing context for overlay.")
+      return
+    }
+
+    const accumulator = createPoseAccumulator()
+    const drawingUtils = new visionModule.DrawingUtils(ctx)
+    sampleTimestampRef.current = 0
+    setIsProcessing(true)
+    setAnalysis(null)
+
+    const handleFrame = () => {
+      if (!video || video.paused || video.ended) {
+        finalizeAnalysis(accumulator)
+        return
+      }
+
+      const now = performance.now()
+      if (now - sampleTimestampRef.current < 80) {
+        animationFrameRef.current = requestAnimationFrame(handleFrame)
+        return
+      }
+
+      sampleTimestampRef.current = now
+      const result = landmarker.detectForVideo(video, now)
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      if (result.landmarks && result.landmarks.length > 0) {
+        const pose = result.landmarks[0]
+        drawingUtils.drawConnectors(pose, visionModule.PoseLandmarker.POSE_CONNECTIONS, {
+          lineWidth: 3,
+          color: "rgba(79, 70, 229, 0.85)",
+        })
+        drawingUtils.drawLandmarks(pose, {
+          radius: 4,
+          fillColor: "rgba(59, 130, 246, 0.9)",
+        })
+        accumulatePoseMetrics(accumulator, pose)
+      }
+
+      animationFrameRef.current = requestAnimationFrame(handleFrame)
+    }
+
+    const handleEnded = () => {
+      finalizeAnalysis(accumulator)
+    }
+
+    const handlePause = () => {
+      if (!video.ended) {
+        finalizeAnalysis(accumulator)
+      }
+    }
+
+    video.addEventListener("ended", handleEnded, { once: true })
+    video.addEventListener("pause", handlePause, { once: true })
+
+    const startPlayback = async () => {
+      try {
+        await video.play()
+        animationFrameRef.current = requestAnimationFrame(handleFrame)
+      } catch (error) {
+        console.error(error)
+        setModelError("Unable to start video playback. Try a different file format.")
+        finalizeAnalysis(accumulator)
+      }
+    }
+
+    video.currentTime = 0
+    startPlayback()
+  }, [finalizeAnalysis])
+
+  const handleAnalyze = useCallback(async () => {
+    if (!uploadedVideoUrl) {
+      setUploadError("Upload a training video before running the analyzer.")
+      return
+    }
+
+    if (!poseLandmarkerRef.current) {
+      await loadPoseLandmarker()
+    }
+
+    resetVideo()
+    processVideo()
+  }, [loadPoseLandmarker, processVideo, resetVideo, uploadedVideoUrl])
+
+  useEffect(() => () => cleanupAnimation(), [cleanupAnimation])
+
+  const handleReset = () => {
+    resetVideo()
+    setAnalysis(null)
+    setUploadError(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""
+    }
+    if (uploadedVideoUrl) {
+      URL.revokeObjectURL(uploadedVideoUrl)
+      setUploadedVideoUrl(null)
+    }
+  }
+
+  return (
+    <Card className="border-primary/20 bg-gradient-to-b from-background to-primary/5">
+      <CardHeader className="gap-3">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="text-2xl">Technique Analyzer</CardTitle>
+            <CardDescription>
+              Upload a training clip to overlay MediaPipe pose tracking and compare key technique metrics
+              against a reference example.
+            </CardDescription>
+          </div>
+          <Badge variant="outline" className="border-primary/40 text-primary">
+            Experimental
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.2fr)]">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground">Exercise focus</label>
+            <select
+              className="w-full rounded-lg border bg-background p-2 text-sm"
+              value={selectedExerciseId}
+              onChange={(event) => setSelectedExerciseId(event.target.value)}
+            >
+              {exerciseExamples.map((example) => (
+                <option key={example.id} value={example.id}>
+                  {example.name}
+                </option>
+              ))}
+            </select>
+            {selectedExercise && (
+              <p className="text-xs text-muted-foreground">{selectedExercise.description}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground">Upload your session</label>
+            <Input
+              ref={fileInputRef}
+              type="file"
+              accept="video/*"
+              onChange={handleFileChange}
+              className="cursor-pointer"
+            />
+            <p className="text-xs text-muted-foreground">
+              Videos are processed on-device in your browser and never leave this session.
+            </p>
+            {uploadError && (
+              <div className="flex items-center gap-2 text-xs text-destructive">
+                <AlertCircle className="h-4 w-4" />
+                <span>{uploadError}</span>
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-3 rounded-xl border border-primary/20 bg-primary/5 p-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-primary">
+              <Video className="h-4 w-4" /> Reference cues
+            </div>
+            <ul className="list-disc space-y-1 pl-5 text-xs text-muted-foreground">
+              {selectedExercise?.cues.map((cue) => (
+                <li key={cue}>{cue}</li>
+              ))}
+            </ul>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleAnalyze}
+              disabled={isProcessing || isModelLoading}
+              className="gap-2"
+            >
+              {isProcessing ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Processing
+                </>
+              ) : (
+                <>
+                  <PlayCircle className="h-4 w-4" />
+                  Analyze technique
+                </>
+              )}
+            </Button>
+            {modelError && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+                <AlertCircle className="mt-0.5 h-4 w-4" />
+                <span>{modelError}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+          <div className="space-y-3">
+            <div className="relative aspect-video overflow-hidden rounded-xl border bg-background">
+              <video ref={videoRef} controls className="h-full w-full object-contain" playsInline />
+              <canvas ref={overlayRef} className="absolute inset-0 h-full w-full" />
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              {comparisonScore !== null && (
+                <Badge className="bg-primary text-primary-foreground">
+                  Technique score: {comparisonScore}% within target
+                </Badge>
+              )}
+              {analysis?.frameCount && (
+                <span className="text-xs text-muted-foreground">
+                  {analysis.frameCount} frames analyzed
+                </span>
+              )}
+              {uploadedVideoUrl && !isProcessing && (
+                <Button variant="ghost" size="sm" onClick={handleAnalyze} className="h-7 px-3 text-xs">
+                  Re-run analysis
+                </Button>
+              )}
+              {uploadedVideoUrl && (
+                <Button variant="ghost" size="sm" onClick={handleReset} className="h-7 px-3 text-xs">
+                  Reset
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="relative aspect-video overflow-hidden rounded-xl border bg-background">
+              <canvas ref={exampleCanvasRef} className="h-full w-full" />
+              <div className="absolute bottom-3 left-3 rounded-full bg-primary/90 px-3 py-1 text-xs font-medium text-primary-foreground">
+                Reference example
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="font-semibold text-foreground">Metric comparison</h3>
+              <div className="grid gap-3">
+                {comparisons.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    Upload a video and run the analyzer to see how your movement stacks up against the reference model.
+                  </p>
+                )}
+                {comparisons.map((comparison) => {
+                  const withinRange = comparison.status === "match"
+                  const badgeVariant = withinRange ? "default" : "outline"
+                  const badgeClass = withinRange
+                    ? "bg-emerald-500 text-emerald-50"
+                    : comparison.status === "missing"
+                      ? "border-border text-muted-foreground"
+                      : "border-amber-500 text-amber-500"
+
+                  return (
+                    <div
+                      key={comparison.metric.key}
+                      className="rounded-lg border border-border/60 bg-background p-3 text-sm"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <p className="font-medium text-foreground">{comparison.metric.label}</p>
+                          <p className="text-xs text-muted-foreground">{comparison.metric.description}</p>
+                        </div>
+                        <Badge variant={badgeVariant} className={badgeClass}>
+                          {comparison.status === "missing"
+                            ? "No data"
+                            : withinRange
+                              ? "On target"
+                              : "Needs attention"}
+                        </Badge>
+                      </div>
+                      <div className="mt-2 grid gap-1 text-xs text-muted-foreground">
+                        <div className="flex items-center justify-between gap-4">
+                          <span className="text-foreground">Your metric</span>
+                          <span className="text-foreground font-medium">
+                            {formatMetricValue(comparison.metric, comparison.value)}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-4">
+                          <span>Reference window</span>
+                          <span>
+                            {formatMetricValue(comparison.metric, comparison.metric.min)} —
+                            {" "}
+                            {formatMetricValue(comparison.metric, comparison.metric.max)}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-4">
+                          <span>Difference</span>
+                          <span>{describeDelta(comparison.metric, comparison.delta)}</span>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/data/exercise-examples.ts
+++ b/src/data/exercise-examples.ts
@@ -1,0 +1,116 @@
+import { NormalizedLandmark, PoseMetricKey } from "@/lib/pose-utils"
+
+export interface ExampleMetricRange {
+  key: PoseMetricKey
+  label: string
+  description: string
+  unit: "degrees" | "ratio"
+  min: number
+  max: number
+}
+
+export interface ExerciseExample {
+  id: string
+  name: string
+  description: string
+  cues: string[]
+  metrics: ExampleMetricRange[]
+  referenceFrames: NormalizedLandmark[][]
+}
+
+const createEmptyPose = (): NormalizedLandmark[] =>
+  Array.from({ length: 33 }, () => ({ x: 0.5, y: 0.5, z: 0 }))
+
+const createSquatFrame = (depth: number): NormalizedLandmark[] => {
+  const frame = createEmptyPose()
+
+  const headY = 0.18 + depth * 0.04
+  const shoulderY = 0.3 + depth * 0.05
+  const hipY = 0.5 + depth * 0.12
+  const kneeY = 0.68 + depth * 0.15
+  const ankleY = 0.9
+
+  const hipShift = depth * 0.03
+  const kneeShift = depth * 0.04
+  const torsoForward = depth * 0.015
+
+  frame[0] = { x: 0.5, y: headY, z: 0 }
+  frame[1] = { x: 0.5, y: headY + 0.02, z: 0 }
+  frame[2] = { x: 0.5, y: headY + 0.04, z: 0 }
+  frame[3] = { x: 0.5, y: headY + 0.06, z: 0 }
+
+  frame[11] = { x: 0.46 + torsoForward, y: shoulderY, z: 0 }
+  frame[12] = { x: 0.54 + torsoForward, y: shoulderY, z: 0 }
+
+  frame[13] = { x: 0.42 + torsoForward * 1.3, y: shoulderY + 0.07, z: 0 }
+  frame[14] = { x: 0.58 + torsoForward * 1.3, y: shoulderY + 0.07, z: 0 }
+  frame[15] = { x: 0.4 + torsoForward * 1.6, y: shoulderY + 0.12, z: 0 }
+  frame[16] = { x: 0.6 + torsoForward * 1.6, y: shoulderY + 0.12, z: 0 }
+
+  frame[23] = { x: 0.46 - hipShift, y: hipY, z: 0 }
+  frame[24] = { x: 0.54 + hipShift, y: hipY, z: 0 }
+
+  frame[25] = { x: 0.46 + kneeShift, y: kneeY, z: 0 }
+  frame[26] = { x: 0.54 - kneeShift, y: kneeY, z: 0 }
+
+  frame[27] = { x: 0.45, y: ankleY, z: 0 }
+  frame[28] = { x: 0.55, y: ankleY, z: 0 }
+
+  frame[19] = { x: 0.44, y: shoulderY + 0.04, z: 0 }
+  frame[20] = { x: 0.56, y: shoulderY + 0.04, z: 0 }
+
+  return frame
+}
+
+const squatReferenceFrames = [0, 0.25, 0.5, 0.75, 1].map(createSquatFrame)
+
+export const exerciseExamples: ExerciseExample[] = [
+  {
+    id: "bodyweight-squat",
+    name: "Bodyweight Squat",
+    description: "Benchmark squat pattern focusing on depth, knee tracking, and posture.",
+    cues: [
+      "Sit the hips back first to load the posterior chain.",
+      "Keep the chest lifted and ribs stacked over the pelvis.",
+      "Drive the knees out so they follow the line of the toes.",
+    ],
+    metrics: [
+      {
+        key: "minKneeAngle",
+        label: "Bottom knee flexion",
+        description: "Target parallel or slightly below parallel depth.",
+        unit: "degrees",
+        min: 80,
+        max: 95,
+      },
+      {
+        key: "maxHipAngle",
+        label: "Hip extension at finish",
+        description: "Full hip extension shows a strong lockout at the top.",
+        unit: "degrees",
+        min: 165,
+        max: 180,
+      },
+      {
+        key: "avgTorsoLean",
+        label: "Average torso lean",
+        description: "Maintain a neutral spine with controlled forward lean.",
+        unit: "degrees",
+        min: 5,
+        max: 20,
+      },
+      {
+        key: "stanceSymmetry",
+        label: "Stance symmetry",
+        description: "Aim for even loading between left and right sides.",
+        unit: "ratio",
+        min: 0,
+        max: 0.05,
+      },
+    ],
+    referenceFrames: squatReferenceFrames,
+  },
+]
+
+export const getExerciseExample = (id: string) =>
+  exerciseExamples.find((example) => example.id === id)

--- a/src/lib/pose-utils.ts
+++ b/src/lib/pose-utils.ts
@@ -1,0 +1,257 @@
+export type NormalizedLandmark = {
+  x: number
+  y: number
+  z: number
+  visibility?: number
+}
+
+type LandmarkTuple = [number, number]
+
+const LANDMARK_INDICES = {
+  LEFT_SHOULDER: 11,
+  RIGHT_SHOULDER: 12,
+  LEFT_HIP: 23,
+  RIGHT_HIP: 24,
+  LEFT_KNEE: 25,
+  RIGHT_KNEE: 26,
+  LEFT_ANKLE: 27,
+  RIGHT_ANKLE: 28,
+}
+
+const DEGREE = 180 / Math.PI
+
+const MIN_VISIBILITY = 0.3
+
+const hasVisibility = (landmark: NormalizedLandmark | undefined) => {
+  if (!landmark) return false
+  if (typeof landmark.visibility !== "number") return true
+  return landmark.visibility >= MIN_VISIBILITY
+}
+
+const isValid = (landmarks: NormalizedLandmark[], indices: number[]) =>
+  indices.every((index) => hasVisibility(landmarks[index]))
+
+const calculateAngle = (
+  a: NormalizedLandmark,
+  b: NormalizedLandmark,
+  c: NormalizedLandmark,
+) => {
+  const ab = { x: a.x - b.x, y: a.y - b.y }
+  const cb = { x: c.x - b.x, y: c.y - b.y }
+  const dot = ab.x * cb.x + ab.y * cb.y
+  const magAB = Math.sqrt(ab.x ** 2 + ab.y ** 2)
+  const magCB = Math.sqrt(cb.x ** 2 + cb.y ** 2)
+  if (magAB === 0 || magCB === 0) return null
+  const cosine = dot / (magAB * magCB)
+  const clamped = Math.min(1, Math.max(-1, cosine))
+  return Math.acos(clamped) * DEGREE
+}
+
+const midpoint = (a: NormalizedLandmark, b: NormalizedLandmark) => ({
+  x: (a.x + b.x) / 2,
+  y: (a.y + b.y) / 2,
+})
+
+export interface PoseMetricAccumulator {
+  minKneeAngle: number
+  maxHipAngle: number
+  torsoLeanSum: number
+  stanceSymmetrySum: number
+  frames: number
+}
+
+export interface PoseAnalysis {
+  minKneeAngle: number | null
+  maxHipAngle: number | null
+  avgTorsoLean: number | null
+  stanceSymmetry: number | null
+  frameCount: number
+}
+
+export const createPoseAccumulator = (): PoseMetricAccumulator => ({
+  minKneeAngle: Number.POSITIVE_INFINITY,
+  maxHipAngle: 0,
+  torsoLeanSum: 0,
+  stanceSymmetrySum: 0,
+  frames: 0,
+})
+
+export const accumulatePoseMetrics = (
+  accumulator: PoseMetricAccumulator,
+  landmarks: NormalizedLandmark[],
+) => {
+  if (!landmarks || landmarks.length === 0) return
+
+  let validFrame = false
+
+  const leftKneeIndices = [
+    LANDMARK_INDICES.LEFT_HIP,
+    LANDMARK_INDICES.LEFT_KNEE,
+    LANDMARK_INDICES.LEFT_ANKLE,
+  ]
+  const rightKneeIndices = [
+    LANDMARK_INDICES.RIGHT_HIP,
+    LANDMARK_INDICES.RIGHT_KNEE,
+    LANDMARK_INDICES.RIGHT_ANKLE,
+  ]
+
+  const kneeAngles: number[] = []
+  if (isValid(landmarks, leftKneeIndices)) {
+    const angle = calculateAngle(
+      landmarks[LANDMARK_INDICES.LEFT_HIP],
+      landmarks[LANDMARK_INDICES.LEFT_KNEE],
+      landmarks[LANDMARK_INDICES.LEFT_ANKLE],
+    )
+    if (typeof angle === "number") {
+      kneeAngles.push(angle)
+      validFrame = true
+    }
+  }
+
+  if (isValid(landmarks, rightKneeIndices)) {
+    const angle = calculateAngle(
+      landmarks[LANDMARK_INDICES.RIGHT_HIP],
+      landmarks[LANDMARK_INDICES.RIGHT_KNEE],
+      landmarks[LANDMARK_INDICES.RIGHT_ANKLE],
+    )
+    if (typeof angle === "number") {
+      kneeAngles.push(angle)
+      validFrame = true
+    }
+  }
+
+  if (kneeAngles.length > 0) {
+    const minKneeAngle = Math.min(...kneeAngles)
+    accumulator.minKneeAngle = Math.min(accumulator.minKneeAngle, minKneeAngle)
+  }
+
+  const hipAngles: number[] = []
+  const leftHipIndices = [
+    LANDMARK_INDICES.LEFT_SHOULDER,
+    LANDMARK_INDICES.LEFT_HIP,
+    LANDMARK_INDICES.LEFT_KNEE,
+  ]
+  const rightHipIndices = [
+    LANDMARK_INDICES.RIGHT_SHOULDER,
+    LANDMARK_INDICES.RIGHT_HIP,
+    LANDMARK_INDICES.RIGHT_KNEE,
+  ]
+
+  if (isValid(landmarks, leftHipIndices)) {
+    const angle = calculateAngle(
+      landmarks[LANDMARK_INDICES.LEFT_SHOULDER],
+      landmarks[LANDMARK_INDICES.LEFT_HIP],
+      landmarks[LANDMARK_INDICES.LEFT_KNEE],
+    )
+    if (typeof angle === "number") {
+      hipAngles.push(angle)
+      validFrame = true
+    }
+  }
+
+  if (isValid(landmarks, rightHipIndices)) {
+    const angle = calculateAngle(
+      landmarks[LANDMARK_INDICES.RIGHT_SHOULDER],
+      landmarks[LANDMARK_INDICES.RIGHT_HIP],
+      landmarks[LANDMARK_INDICES.RIGHT_KNEE],
+    )
+    if (typeof angle === "number") {
+      hipAngles.push(angle)
+      validFrame = true
+    }
+  }
+
+  if (hipAngles.length > 0) {
+    const maxHipAngle = Math.max(...hipAngles)
+    accumulator.maxHipAngle = Math.max(accumulator.maxHipAngle, maxHipAngle)
+  }
+
+  if (
+    isValid(landmarks, [
+      LANDMARK_INDICES.LEFT_SHOULDER,
+      LANDMARK_INDICES.RIGHT_SHOULDER,
+      LANDMARK_INDICES.LEFT_HIP,
+      LANDMARK_INDICES.RIGHT_HIP,
+    ])
+  ) {
+    const leftShoulder = landmarks[LANDMARK_INDICES.LEFT_SHOULDER]
+    const rightShoulder = landmarks[LANDMARK_INDICES.RIGHT_SHOULDER]
+    const leftHip = landmarks[LANDMARK_INDICES.LEFT_HIP]
+    const rightHip = landmarks[LANDMARK_INDICES.RIGHT_HIP]
+
+    const shouldersMid = midpoint(leftShoulder, rightShoulder)
+    const hipsMid = midpoint(leftHip, rightHip)
+    const torso = { x: shouldersMid.x - hipsMid.x, y: shouldersMid.y - hipsMid.y }
+
+    const leanRadians = Math.atan2(torso.x, -torso.y)
+    const leanDegrees = Math.abs(leanRadians * DEGREE)
+    accumulator.torsoLeanSum += leanDegrees
+    validFrame = true
+  }
+
+  if (
+    isValid(landmarks, [
+      LANDMARK_INDICES.LEFT_ANKLE,
+      LANDMARK_INDICES.RIGHT_ANKLE,
+      LANDMARK_INDICES.LEFT_HIP,
+      LANDMARK_INDICES.RIGHT_HIP,
+    ])
+  ) {
+    const leftAnkle = landmarks[LANDMARK_INDICES.LEFT_ANKLE]
+    const rightAnkle = landmarks[LANDMARK_INDICES.RIGHT_ANKLE]
+    const leftHip = landmarks[LANDMARK_INDICES.LEFT_HIP]
+    const rightHip = landmarks[LANDMARK_INDICES.RIGHT_HIP]
+
+    const leftDistance = Math.abs(leftAnkle.x - leftHip.x)
+    const rightDistance = Math.abs(rightAnkle.x - rightHip.x)
+    const stanceDiff = Math.abs(leftDistance - rightDistance)
+    accumulator.stanceSymmetrySum += stanceDiff
+    validFrame = true
+  }
+
+  if (validFrame) {
+    accumulator.frames += 1
+  }
+}
+
+export const finalizePoseMetrics = (
+  accumulator: PoseMetricAccumulator,
+): PoseAnalysis => ({
+  minKneeAngle:
+    accumulator.minKneeAngle === Number.POSITIVE_INFINITY
+      ? null
+      : accumulator.minKneeAngle,
+  maxHipAngle: accumulator.maxHipAngle === 0 ? null : accumulator.maxHipAngle,
+  avgTorsoLean:
+    accumulator.frames === 0 ? null : accumulator.torsoLeanSum / accumulator.frames,
+  stanceSymmetry:
+    accumulator.frames === 0
+      ? null
+      : accumulator.stanceSymmetrySum / accumulator.frames,
+  frameCount: accumulator.frames,
+})
+
+export const REFERENCE_CONNECTIONS: LandmarkTuple[] = [
+  [11, 12],
+  [11, 23],
+  [12, 24],
+  [23, 24],
+  [23, 25],
+  [25, 27],
+  [24, 26],
+  [26, 28],
+  [11, 13],
+  [13, 15],
+  [12, 14],
+  [14, 16],
+  [15, 21],
+  [16, 22],
+]
+
+export type PoseMetricKey = keyof Omit<PoseAnalysis, "frameCount">
+
+export const formatDegrees = (value: number | null, fractionDigits = 1) =>
+  typeof value === "number" ? `${value.toFixed(fractionDigits)}°` : "—"
+
+export const formatRatio = (value: number | null, fractionDigits = 3) =>
+  typeof value === "number" ? value.toFixed(fractionDigits) : "—"


### PR DESCRIPTION
## Summary
- add a technique analyzer card on the training page that lets athletes upload clips, runs MediaPipe pose tracking in the browser, and compares results to reference metrics
- introduce pose metric utilities and reference example data that drive MediaPipe overlays and comparison feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0045f3f3c83238e7e3f0c52edf07b