### PR TITLE
Update meal logging display and rounding

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -49,6 +49,12 @@ const formatDate = (value: string) => {
   })
 }
 
+const formatTwoDecimalString = (value: number): string => {
+  if (!Number.isFinite(value)) return "0"
+  const rounded = Math.round(value * 100) / 100
+  return Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2)
+}
+
 const formatTimeRange = (start?: string, end?: string) => {
   if (!start || !end) return ""
   const startDate = new Date(start)
@@ -656,7 +662,7 @@ export default function Account() {
                     </div>
                     <div className="text-right text-xs text-muted-foreground">
                       <p>{meal.calories} kcal</p>
-                      <p>{meal.proteinG}g protein</p>
+                      <p>{formatTwoDecimalString(meal.proteinG)}g protein</p>
                     </div>
                   </div>
                 ))


### PR DESCRIPTION
## Summary
- round nutrition fact details and protein totals to two decimal places across fuel and account views
- switch meal log metadata to show the entry date with a calendar icon instead of an auto-filled time
- streamline manual logging by emphasising the breakfast/lunch/dinner category dropdown while preserving imported menu types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f18b12447883239ad857496410984f