### PR TITLE
Add persistent auth and session synchronization

### DIFF
--- a/data/locker-store.json
+++ b/data/locker-store.json
@@ -1,0 +1,108 @@
+{
+  "accounts": [],
+  "athletes": [
+    {
+      "id": 1,
+      "name": "Alex Johnson",
+      "email": "alex.johnson@locker.app",
+      "sport": "Track & Field",
+      "level": "Elite",
+      "team": "Sprints",
+      "tags": ["track", "sprints"],
+      "sessions": [
+        {
+          "id": 1,
+          "type": "practice",
+          "title": "Morning Practice",
+          "startAt": "2024-01-15T06:00:00Z",
+          "endAt": "2024-01-15T08:00:00Z",
+          "intensity": "high",
+          "notes": "Focus on technique",
+          "completed": true,
+          "assignedBy": "Coach Rivera",
+          "focus": "Acceleration Drills"
+        }
+      ],
+      "calendar": [
+        {
+          "id": 1,
+          "title": "Morning Practice",
+          "date": "2024-01-15",
+          "timeRange": "6:00 AM - 8:00 AM",
+          "type": "practice",
+          "focus": "Acceleration Drills"
+        }
+      ],
+      "workouts": [
+        {
+          "id": 1,
+          "title": "Acceleration Drills",
+          "focus": "Speed Mechanics",
+          "dueDate": "2024-01-15",
+          "status": "Completed",
+          "intensity": "high",
+          "assignedBy": "Coach Rivera"
+        }
+      ],
+      "hydrationLogs": [
+        { "id": 1, "date": "2024-01-15", "ounces": 8, "source": "cup", "time": "08:00" },
+        { "id": 2, "date": "2024-01-15", "ounces": 12, "source": "bottle", "time": "10:30" },
+        { "id": 3, "date": "2024-01-15", "ounces": 8, "source": "cup", "time": "12:00" },
+        { "id": 4, "date": "2024-01-15", "ounces": 17, "source": "shake", "time": "14:00" },
+        { "id": 5, "date": "2024-01-15", "ounces": 8, "source": "cup", "time": "16:30" }
+      ],
+      "mealLogs": [
+        {
+          "id": 1,
+          "dateTime": "2024-01-15T08:00:00Z",
+          "mealType": "breakfast",
+          "calories": 450,
+          "proteinG": 25,
+          "notes": "Oatmeal with berries and protein powder",
+          "completed": true,
+          "nutritionFacts": []
+        },
+        {
+          "id": 2,
+          "dateTime": "2024-01-15T12:30:00Z",
+          "mealType": "lunch",
+          "calories": 650,
+          "proteinG": 40,
+          "notes": "Grilled chicken salad",
+          "completed": true,
+          "nutritionFacts": []
+        },
+        {
+          "id": 3,
+          "dateTime": "2024-01-15T18:00:00Z",
+          "mealType": "dinner",
+          "calories": 0,
+          "proteinG": 0,
+          "notes": "Planned: Salmon with quinoa",
+          "completed": false,
+          "nutritionFacts": []
+        },
+        {
+          "id": 4,
+          "dateTime": "2024-01-15T15:00:00Z",
+          "mealType": "snack",
+          "calories": 200,
+          "proteinG": 15,
+          "notes": "Greek yogurt with nuts",
+          "completed": true,
+          "nutritionFacts": []
+        }
+      ],
+      "coachEmail": "coach.rivera@locker.app",
+      "position": "Sprint Specialist",
+      "heightCm": 175,
+      "weightKg": 70,
+      "allergies": ["Peanuts", "Shellfish"],
+      "phone": "+1 (555) 123-4567",
+      "location": "San Francisco, CA",
+      "university": "University of California",
+      "graduationYear": "2025",
+      "isSeedData": true
+    }
+  ]
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from "next/server"
+
+import type { UserAccount } from "@/lib/role-types"
+import { createSessionToken } from "@/lib/server/auth-token"
+import {
+  getNextAthleteId,
+  readLockerState,
+  writeLockerState,
+} from "@/lib/server/persistent-store"
+
+const normalizeEmail = (email: unknown) =>
+  typeof email === "string" ? email.trim().toLowerCase() : ""
+
+export async function POST(request: Request) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+  }
+
+  const payload = body as {
+    email?: unknown
+    password?: unknown
+    role?: unknown
+  }
+
+  const email = normalizeEmail(payload.email)
+  const role = payload.role === "coach" ? "coach" : payload.role === "athlete" ? "athlete" : null
+  const password = typeof payload.password === "string" ? payload.password : ""
+
+  if (!email) {
+    return NextResponse.json({ error: "Email is required." }, { status: 400 })
+  }
+
+  if (!role) {
+    return NextResponse.json({ error: "Role is required." }, { status: 400 })
+  }
+
+  if (!password) {
+    return NextResponse.json({ error: "Password is required." }, { status: 400 })
+  }
+
+  const current = await readLockerState()
+  const accountIndex = current.accounts.findIndex(
+    (account) => account.email === email && account.role === role
+  )
+
+  if (accountIndex === -1) {
+    return NextResponse.json({ error: "Account not found." }, { status: 404 })
+  }
+
+  const account = current.accounts[accountIndex]
+
+  if (account.password !== password) {
+    return NextResponse.json({ error: "Invalid credentials." }, { status: 401 })
+  }
+
+  let nextAccounts = current.accounts
+  let nextAthletes = current.athletes
+  let athleteId = account.athleteId
+
+  if (role === "athlete") {
+    if (athleteId == null) {
+      athleteId = getNextAthleteId(current.athletes)
+      const inferredName = account.name || email.split("@")[0] || email
+      const newAthlete = {
+        id: athleteId,
+        name: inferredName,
+        email,
+        sport: "",
+        level: "",
+        team: "",
+        tags: [],
+        sessions: [],
+        calendar: [],
+        workouts: [],
+        hydrationLogs: [],
+        mealLogs: [],
+      }
+
+      nextAthletes = [
+        ...current.athletes.filter((athlete) => !athlete.isSeedData),
+        newAthlete,
+      ]
+      nextAccounts = current.accounts.map((stored, index) =>
+        index === accountIndex ? { ...stored, athleteId } : stored
+      )
+    } else {
+      const existingAthlete = current.athletes.find((athlete) => athlete.id === athleteId)
+      if (!existingAthlete) {
+        const inferredName = account.name || email.split("@")[0] || email
+        const newAthlete = {
+          id: athleteId,
+          name: inferredName,
+          email,
+          sport: "",
+          level: "",
+          team: "",
+          tags: [],
+          sessions: [],
+          calendar: [],
+          workouts: [],
+          hydrationLogs: [],
+          mealLogs: [],
+        }
+        nextAthletes = [
+          ...current.athletes.filter((athlete) => athlete.id !== athleteId && !athlete.isSeedData),
+          newAthlete,
+        ]
+      }
+    }
+  }
+
+  if (nextAccounts !== current.accounts || nextAthletes !== current.athletes) {
+    await writeLockerState({ accounts: nextAccounts, athletes: nextAthletes })
+  }
+
+  const token = createSessionToken(email, role)
+  const user: UserAccount = {
+    email,
+    name: account.name,
+    role,
+    ...(athleteId ? { athleteId } : {}),
+  }
+
+  return NextResponse.json({ token, user, athletes: nextAthletes })
+}

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server"
+
+import type { UserAccount } from "@/lib/role-types"
+import { verifySessionToken } from "@/lib/server/auth-token"
+import {
+  getNextAthleteId,
+  readLockerState,
+  writeLockerState,
+} from "@/lib/server/persistent-store"
+
+const extractToken = (headerValue: string | null) => {
+  if (!headerValue) return null
+  const [scheme, token] = headerValue.split(" ")
+  if (!scheme || scheme.toLowerCase() !== "bearer" || !token) return null
+  return token.trim()
+}
+
+export async function GET(request: Request) {
+  const token = extractToken(request.headers.get("authorization"))
+  const claims = verifySessionToken(token)
+
+  if (!claims) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const current = await readLockerState()
+  const accountIndex = current.accounts.findIndex(
+    (account) => account.email === claims.email && account.role === claims.role
+  )
+
+  if (accountIndex === -1) {
+    return NextResponse.json({ error: "Session no longer valid" }, { status: 401 })
+  }
+
+  const account = current.accounts[accountIndex]
+  let nextAccounts = current.accounts
+  let nextAthletes = current.athletes
+  let athleteId = account.athleteId
+
+  if (account.role === "athlete") {
+    if (athleteId == null) {
+      athleteId = getNextAthleteId(current.athletes)
+      const inferredName = account.name || account.email.split("@")[0] || account.email
+      const newAthlete = {
+        id: athleteId,
+        name: inferredName,
+        email: account.email,
+        sport: "",
+        level: "",
+        team: "",
+        tags: [],
+        sessions: [],
+        calendar: [],
+        workouts: [],
+        hydrationLogs: [],
+        mealLogs: [],
+      }
+      nextAthletes = [
+        ...current.athletes.filter((athlete) => !athlete.isSeedData),
+        newAthlete,
+      ]
+      nextAccounts = current.accounts.map((stored, index) =>
+        index === accountIndex ? { ...stored, athleteId } : stored
+      )
+    } else {
+      const existingAthlete = current.athletes.find((athlete) => athlete.id === athleteId)
+      if (!existingAthlete) {
+        const inferredName = account.name || account.email.split("@")[0] || account.email
+        const newAthlete = {
+          id: athleteId,
+          name: inferredName,
+          email: account.email,
+          sport: "",
+          level: "",
+          team: "",
+          tags: [],
+          sessions: [],
+          calendar: [],
+          workouts: [],
+          hydrationLogs: [],
+          mealLogs: [],
+        }
+        nextAthletes = [
+          ...current.athletes.filter((athlete) => athlete.id !== athleteId && !athlete.isSeedData),
+          newAthlete,
+        ]
+      }
+    }
+  }
+
+  if (nextAccounts !== current.accounts || nextAthletes !== current.athletes) {
+    await writeLockerState({ accounts: nextAccounts, athletes: nextAthletes })
+  }
+
+  const user: UserAccount = {
+    email: account.email,
+    name: account.name,
+    role: account.role,
+    ...(athleteId ? { athleteId } : {}),
+  }
+
+  return NextResponse.json({ user, athletes: nextAthletes })
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server"
+
+import type { UserAccount } from "@/lib/role-types"
+import { createSessionToken } from "@/lib/server/auth-token"
+import {
+  getNextAthleteId,
+  readLockerState,
+  writeLockerState,
+  type LockerPersistentState,
+} from "@/lib/server/persistent-store"
+
+const normalizeEmail = (email: unknown) =>
+  typeof email === "string" ? email.trim().toLowerCase() : ""
+
+const normalizeName = (name: unknown, email: string) => {
+  if (typeof name === "string" && name.trim()) {
+    return name.trim()
+  }
+  return email.split("@")[0] ?? email
+}
+
+const isValidPassword = (password: unknown) =>
+  typeof password === "string" && password.length >= 8
+
+export async function POST(request: Request) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+  }
+
+  const payload = body as {
+    email?: unknown
+    password?: unknown
+    role?: unknown
+    name?: unknown
+  }
+
+  const email = normalizeEmail(payload.email)
+  const role = payload.role === "coach" ? "coach" : payload.role === "athlete" ? "athlete" : null
+  const password = typeof payload.password === "string" ? payload.password : ""
+  const name = normalizeName(payload.name, email)
+
+  if (!email) {
+    return NextResponse.json({ error: "Email is required." }, { status: 400 })
+  }
+
+  if (!role) {
+    return NextResponse.json({ error: "Role is required." }, { status: 400 })
+  }
+
+  if (!isValidPassword(password)) {
+    return NextResponse.json(
+      { error: "Password must be at least 8 characters long." },
+      { status: 400 }
+    )
+  }
+
+  const current = await readLockerState()
+  const existing = current.accounts.find(
+    (account) => account.email === email && account.role === role
+  )
+
+  if (existing) {
+    return NextResponse.json(
+      { error: "An account with that email already exists." },
+      { status: 409 }
+    )
+  }
+
+  let athleteId: number | undefined
+  let nextAthletes: LockerPersistentState["athletes"] = current.athletes
+
+  if (role === "athlete") {
+    athleteId = getNextAthleteId(current.athletes)
+    const newAthlete = {
+      id: athleteId,
+      name,
+      email,
+      sport: "",
+      level: "",
+      team: "",
+      tags: [],
+      sessions: [],
+      calendar: [],
+      workouts: [],
+      hydrationLogs: [],
+      mealLogs: [],
+    }
+
+    nextAthletes = [
+      ...current.athletes.filter((athlete) => !athlete.isSeedData),
+      newAthlete,
+    ]
+  }
+
+  const newAccount = {
+    email,
+    name,
+    role,
+    password,
+    athleteId,
+  }
+
+  const nextState: LockerPersistentState = {
+    accounts: [...current.accounts, newAccount],
+    athletes: nextAthletes,
+  }
+
+  await writeLockerState(nextState)
+
+  const token = createSessionToken(email, role)
+  const user: UserAccount = {
+    email,
+    name,
+    role,
+    ...(athleteId ? { athleteId } : {}),
+  }
+
+  return NextResponse.json(
+    {
+      token,
+      user,
+      athletes: nextState.athletes,
+    },
+    { status: 201 }
+  )
+}

--- a/src/lib/server/auth-token.ts
+++ b/src/lib/server/auth-token.ts
@@ -1,0 +1,107 @@
+import crypto from "crypto"
+
+import type { Role } from "@/lib/role-types"
+
+type SessionClaims = {
+  email: string
+  role: Role
+  iat: number
+  exp: number
+}
+
+const base64UrlEncode = (input: Buffer | string) =>
+  Buffer.from(input)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+
+const base64UrlDecode = (input: string) =>
+  Buffer.from(input.replace(/-/g, "+").replace(/_/g, "/"), "base64")
+
+const JWT_HEADER = base64UrlEncode(
+  JSON.stringify({ alg: "HS256", typ: "JWT" })
+)
+
+const getSecret = () =>
+  process.env.LOCKER_AUTH_SECRET ?? "locker-development-secret"
+
+const TOKEN_TTL_MS = 1000 * 60 * 60 * 24 * 30 // 30 days
+
+const sign = (unsignedToken: string) =>
+  crypto.createHmac("sha256", getSecret()).update(unsignedToken).digest()
+
+export const createSessionToken = (email: string, role: Role) => {
+  const issuedAt = Date.now()
+  const claims: SessionClaims = {
+    email,
+    role,
+    iat: issuedAt,
+    exp: issuedAt + TOKEN_TTL_MS,
+  }
+
+  const payload = base64UrlEncode(JSON.stringify(claims))
+  const unsignedToken = `${JWT_HEADER}.${payload}`
+  const signature = base64UrlEncode(sign(unsignedToken))
+  return `${unsignedToken}.${signature}`
+}
+
+export const verifySessionToken = (token: string | null | undefined): SessionClaims | null => {
+  if (!token || typeof token !== "string") {
+    return null
+  }
+
+  const parts = token.split(".")
+  if (parts.length !== 3) {
+    return null
+  }
+
+  const [header, payload, providedSignature] = parts
+  if (header !== JWT_HEADER) {
+    return null
+  }
+
+  const unsignedToken = `${header}.${payload}`
+  const expectedDigest = sign(unsignedToken)
+  let providedDigest: Buffer
+  try {
+    providedDigest = base64UrlDecode(providedSignature)
+  } catch {
+    return null
+  }
+
+  if (
+    expectedDigest.length !== providedDigest.length ||
+    !crypto.timingSafeEqual(expectedDigest, providedDigest)
+  ) {
+    return null
+  }
+
+  let claims: SessionClaims
+  try {
+    const decoded = base64UrlDecode(payload).toString("utf8")
+    claims = JSON.parse(decoded) as SessionClaims
+  } catch {
+    return null
+  }
+
+  if (!claims || typeof claims !== "object") {
+    return null
+  }
+
+  if (typeof claims.email !== "string" || typeof claims.role !== "string") {
+    return null
+  }
+
+  if (typeof claims.exp !== "number" || typeof claims.iat !== "number") {
+    return null
+  }
+
+  if (Date.now() >= claims.exp) {
+    return null
+  }
+
+  return claims
+}
+
+export type { SessionClaims }

--- a/src/lib/server/persistent-store.ts
+++ b/src/lib/server/persistent-store.ts
@@ -1,0 +1,72 @@
+import { promises as fs } from "fs"
+import path from "path"
+
+import { initialAthletes } from "@/lib/initial-data"
+import type { Athlete, StoredAccount } from "@/lib/role-types"
+import { normalizeAccounts, normalizeAthletes } from "@/lib/state-normalizer"
+
+export type LockerPersistentState = {
+  accounts: StoredAccount[]
+  athletes: Athlete[]
+}
+
+const clone = <T,>(value: T): T =>
+  JSON.parse(JSON.stringify(value)) as T
+
+const DATA_DIR = path.join(process.cwd(), "data")
+const DATA_FILE = path.join(DATA_DIR, "locker-store.json")
+
+const ensureDataFile = async () => {
+  await fs.mkdir(DATA_DIR, { recursive: true })
+  try {
+    await fs.access(DATA_FILE)
+  } catch {
+    const initialState: LockerPersistentState = {
+      accounts: [],
+      athletes: clone(initialAthletes),
+    }
+    await fs.writeFile(DATA_FILE, JSON.stringify(initialState, null, 2), "utf8")
+  }
+}
+
+export const readLockerState = async (): Promise<LockerPersistentState> => {
+  await ensureDataFile()
+  try {
+    const raw = await fs.readFile(DATA_FILE, "utf8")
+    const parsed = JSON.parse(raw) as Partial<LockerPersistentState>
+    const accounts = normalizeAccounts(parsed?.accounts ?? [])
+    const athletes = normalizeAthletes(parsed?.athletes ?? [])
+    return { accounts, athletes }
+  } catch {
+    const fallback: LockerPersistentState = {
+      accounts: [],
+      athletes: clone(initialAthletes),
+    }
+    await fs.writeFile(DATA_FILE, JSON.stringify(fallback, null, 2), "utf8")
+    return fallback
+  }
+}
+
+export const writeLockerState = async (state: LockerPersistentState) => {
+  await ensureDataFile()
+  const payload: LockerPersistentState = {
+    accounts: state.accounts.map((account) => ({ ...account })),
+    athletes: state.athletes.map((athlete) => ({ ...athlete })),
+  }
+  await fs.writeFile(DATA_FILE, JSON.stringify(payload, null, 2), "utf8")
+}
+
+export const withLockerState = async (
+  updater: (state: LockerPersistentState) => LockerPersistentState
+): Promise<LockerPersistentState> => {
+  const current = await readLockerState()
+  const next = updater(current)
+  await writeLockerState(next)
+  return next
+}
+
+export const getNextAthleteId = (athletes: Athlete[]) => {
+  const maxId = athletes.reduce((max, athlete) => Math.max(max, athlete.id), 0)
+  const candidate = maxId + 1
+  return candidate > 0 ? candidate : Date.now()
+}


### PR DESCRIPTION
## Summary
- add a JSON-backed persistent store with auth token utilities for server use
- expose signup, login, session, and state routes that rely on the persistent store
- refactor the client RoleProvider and login dialog to use server auth and cached session tokens for hydration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5a055e4c48323904488345d445e5c