### PR TITLE
Add Prisma ORM setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@prisma/client": "^5.22.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",
@@ -35,6 +36,7 @@
     "eslint-config-next": "15.5.4",
     "playwright": "^1.56.0",
     "postcss": "^8.5.6",
+    "prisma": "^5.22.0",
     "tailwindcss": "^3.4.17",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,51 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+
+model User {
+  id                 Int                  @id @default(autoincrement())
+  email              String               @unique
+  name               String?
+  role               Role                 @default(USER)
+  passwordCredential PasswordCredentials?
+  athleteProfile     AthleteProfile?
+  sessionTokens      SessionToken[]
+
+  @@map("users")
+}
+
+model PasswordCredentials {
+  userId       Int    @id
+  passwordHash String
+  user         User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("password_credentials")
+}
+
+model AthleteProfile {
+  id     Int   @id @default(autoincrement())
+  userId Int   @unique
+  user   User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("athlete_profiles")
+}
+
+model SessionToken {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  token     String   @unique
+  expiresAt DateTime
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("session_tokens")
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}
+
+export default prisma


### PR DESCRIPTION
## Summary
- add Prisma schema defining users, credentials, athlete profiles, and session tokens
- add a Prisma client singleton for use within the Next.js App Router
- include Prisma packages in the project dependencies

## Testing
- npx prisma generate *(fails: 403 Forbidden fetching prisma package in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f990cc73ac83239478da0c65c7e75b