### PR TITLE
Add bcrypt-based session auth utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "bcrypt": "^5.1.1",
     "lucide-react": "^0.544.0",
     "next": "15.5.4",
     "react": "19.1.0",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,64 @@
+import bcrypt from 'bcrypt'
+import { cookies } from 'next/headers'
+import { randomBytes } from 'node:crypto'
+
+import prisma from './prisma'
+
+const SALT_ROUNDS = 12
+export const SESSION_COOKIE_NAME = 'session_token'
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30 // 30 days
+
+export const hashPassword = async (password: string): Promise<string> => {
+  return bcrypt.hash(password, SALT_ROUNDS)
+}
+
+export const verifyPassword = async (password: string, hash: string): Promise<boolean> => {
+  return bcrypt.compare(password, hash)
+}
+
+export const createSession = async (userId: number): Promise<void> => {
+  const token = randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_SECONDS * 1000)
+
+  await prisma.sessionToken.create({
+    data: {
+      userId,
+      token,
+      expiresAt,
+    },
+  })
+
+  const cookieStore = cookies()
+  cookieStore.set({
+    name: SESSION_COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+    maxAge: SESSION_MAX_AGE_SECONDS,
+    expires: expiresAt,
+  })
+}
+
+export const destroySession = async (): Promise<void> => {
+  const cookieStore = cookies()
+  const existingToken = cookieStore.get(SESSION_COOKIE_NAME)?.value
+
+  if (existingToken) {
+    await prisma.sessionToken.deleteMany({
+      where: { token: existingToken },
+    })
+  }
+
+  cookieStore.set({
+    name: SESSION_COOKIE_NAME,
+    value: '',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+    maxAge: 0,
+    expires: new Date(0),
+  })
+}


### PR DESCRIPTION
## Summary
- add reusable authentication helpers that hash passwords with bcrypt and persist session tokens in Prisma while setting secure cookies
- add the bcrypt dependency for password hashing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f99712656c83239fec412e5f3eccac