### PR TITLE
Implement authentication API routes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,8 @@ datasource db {
 }
 
 enum Role {
-  USER
+  ATHLETE
+  COACH
   ADMIN
 }
 
@@ -16,7 +17,7 @@ model User {
   id                 Int                  @id @default(autoincrement())
   email              String               @unique
   name               String?
-  role               Role                 @default(USER)
+  role               Role                 @default(ATHLETE)
   passwordCredential PasswordCredentials?
   athleteProfile     AthleteProfile?
   sessionTokens      SessionToken[]

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { createSession, verifyPassword } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+const toPublicUser = (user: { id: number; email: string; name: string | null; role: string }) => ({
+  id: user.id,
+  email: user.email,
+  name: user.name,
+  role: user.role,
+})
+
+type LoginBody = {
+  email?: unknown
+  password?: unknown
+}
+
+const normalizeLoginBody = (body: LoginBody): { email: string; password: string } | null => {
+  if (!body || typeof body !== "object") {
+    return null
+  }
+
+  const { email, password } = body
+
+  if (typeof email !== "string" || !email.trim()) {
+    return null
+  }
+
+  const normalizedEmail = email.trim().toLowerCase()
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+    return null
+  }
+
+  if (typeof password !== "string" || password.length === 0) {
+    return null
+  }
+
+  return { email: normalizedEmail, password }
+}
+
+export async function POST(request: NextRequest) {
+  let body: LoginBody
+  try {
+    body = (await request.json()) as LoginBody
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload." }, { status: 400 })
+  }
+
+  const normalized = normalizeLoginBody(body)
+  if (!normalized) {
+    return NextResponse.json({ error: "Invalid login credentials." }, { status: 400 })
+  }
+
+  const { email, password } = normalized
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    include: { passwordCredential: true },
+  })
+
+  if (!user || !user.passwordCredential) {
+    return NextResponse.json({ error: "Invalid email or password." }, { status: 401 })
+  }
+
+  const isValid = await verifyPassword(password, user.passwordCredential.passwordHash)
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid email or password." }, { status: 401 })
+  }
+
+  await createSession(user.id)
+
+  return NextResponse.json({ user: toPublicUser(user) })
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server"
+
+import { destroySession } from "@/lib/auth"
+
+export async function POST() {
+  await destroySession()
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { Prisma } from "@prisma/client"
+import { createSession, hashPassword } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+const VALID_ROLES = ["ATHLETE", "COACH"] as const
+type AllowedRole = (typeof VALID_ROLES)[number]
+
+type RegisterBody = {
+  email?: unknown
+  password?: unknown
+  name?: unknown
+  role?: unknown
+}
+
+type NormalizedRegisterBody = {
+  email: string
+  password: string
+  name: string | null
+  role: AllowedRole
+}
+
+const normalizeRegisterBody = (body: RegisterBody): NormalizedRegisterBody | null => {
+  if (!body || typeof body !== "object") {
+    return null
+  }
+
+  const { email, password, name, role } = body
+
+  if (typeof email !== "string" || !email.trim()) {
+    return null
+  }
+
+  const normalizedEmail = email.trim().toLowerCase()
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+    return null
+  }
+
+  if (typeof password !== "string" || password.length < 8) {
+    return null
+  }
+
+  if (name != null && typeof name !== "string") {
+    return null
+  }
+
+  const providedRole = role == null ? "ATHLETE" : role
+  if (typeof providedRole !== "string") {
+    return null
+  }
+
+  const normalizedRole = providedRole.toUpperCase()
+  if (!VALID_ROLES.includes(normalizedRole as AllowedRole)) {
+    return null
+  }
+
+  return {
+    email: normalizedEmail,
+    password,
+    name: name == null ? null : name.trim() || null,
+    role: normalizedRole as AllowedRole,
+  }
+}
+
+const toPublicUser = (user: { id: number; email: string; name: string | null; role: string }) => ({
+  id: user.id,
+  email: user.email,
+  name: user.name,
+  role: user.role,
+})
+
+export async function POST(request: NextRequest) {
+  let body: RegisterBody
+
+  try {
+    body = (await request.json()) as RegisterBody
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload." }, { status: 400 })
+  }
+
+  const normalized = normalizeRegisterBody(body)
+  if (!normalized) {
+    return NextResponse.json({ error: "Invalid registration details." }, { status: 400 })
+  }
+
+  const { email, password, name, role } = normalized
+
+  const existingUser = await prisma.user.findUnique({ where: { email } })
+  if (existingUser) {
+    return NextResponse.json({ error: "An account with that email already exists." }, { status: 409 })
+  }
+
+  const passwordHash = await hashPassword(password)
+
+  try {
+    const user = await prisma.user.create({
+      data: {
+        email,
+        name,
+        role,
+        passwordCredential: {
+          create: {
+            passwordHash,
+          },
+        },
+        athleteProfile:
+          role === "ATHLETE"
+            ? {
+                create: {},
+              }
+            : undefined,
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+      },
+    })
+
+    await createSession(user.id)
+
+    return NextResponse.json({ user: toPublicUser(user) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json(
+        { error: "An account with that email already exists." },
+        { status: 409 }
+      )
+    }
+
+    console.error("Failed to register user", error)
+    return NextResponse.json({ error: "Unable to register user." }, { status: 500 })
+  }
+}

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,0 +1,43 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { SESSION_COOKIE_NAME, destroySession } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+const toPublicUser = (user: { id: number; email: string; name: string | null; role: string }) => ({
+  id: user.id,
+  email: user.email,
+  name: user.name,
+  role: user.role,
+})
+
+export async function GET() {
+  const cookieStore = await cookies()
+  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value
+
+  if (!token) {
+    return NextResponse.json({ error: "Not authenticated." }, { status: 401 })
+  }
+
+  const session = await prisma.sessionToken.findUnique({
+    where: { token },
+    select: {
+      expiresAt: true,
+      user: {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          role: true,
+        },
+      },
+    },
+  })
+
+  if (!session || session.expiresAt <= new Date()) {
+    await destroySession()
+    return NextResponse.json({ error: "Session expired." }, { status: 401 })
+  }
+
+  return NextResponse.json({ user: toPublicUser(session.user) })
+}


### PR DESCRIPTION
## Summary
- add register, login, logout, and me API routes with validation, password hashing, and session handling
- automatically create athlete profiles for new athlete accounts while issuing a session cookie
- extend the Prisma Role enum to support athlete and coach roles with an athlete default

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f99b8ad3d48323926bd2e2725f3ac5