### PR TITLE
Add Academics model to Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   role               Role                 @default(ATHLETE)
   passwordCredential PasswordCredentials?
   athleteProfile     AthleteProfile?
+  academics          Academics?
   sessionTokens      SessionToken[]
 
   @@map("users")
@@ -54,6 +55,14 @@ model AthleteProfile {
   nutritionGoals Json?
 
   @@map("athlete_profiles")
+}
+
+model Academics {
+  userId  Int  @id
+  payload Json
+  user    User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("academics")
 }
 
 model SessionToken {


### PR DESCRIPTION
## Summary
- add an Academics model mapped to the users table with a JSON payload
- connect the new model to the existing User relation

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68fa61aa00288323af51b8811127c7cc