### PR TITLE
Sync academics data through role context

### DIFF
--- a/src/lib/academics.ts
+++ b/src/lib/academics.ts
@@ -77,6 +77,11 @@ export type Course = {
   source?: "manual" | "ics"
 }
 
+export type AcademicsState = {
+  courses: Course[]
+  academicItems: AcademicItem[]
+}
+
 export type AcademicsUpdateDetail = {
   count: number
 }


### PR DESCRIPTION
## Summary
- add a reusable `AcademicsState` type to share course/item payloads
- extend the role context with academics sanitizers, state management, and server syncing
- refactor the Academics page to consume the shared state for SQL users while keeping guest fallbacks and local storage updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa7bd040d48323a419babb09c9a0f5