### PR TITLE
Persist athlete check-in diary across devices

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   workoutLogs        WorkoutLog[]
   mobilityExercises  MobilityExercise[]
   mobilityLogs       MobilityLog[]
+  checkInLogs        CheckInLog[]
 
   @@map("users")
 }
@@ -40,9 +41,9 @@ model PasswordCredentials {
 }
 
 model AthleteProfile {
-  id             Int     @id @default(autoincrement())
-  userId         Int     @unique
-  user           User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id             Int      @id @default(autoincrement())
+  userId         Int      @unique
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   sport          String?
   level          String?
   team           String?
@@ -103,7 +104,7 @@ model HydrationLog {
   ounces Int
   source String
   time   String
-  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, id])
   @@map("hydration_logs")
@@ -118,36 +119,51 @@ model WorkoutLog {
   status     String
   intensity  String
   assignedBy String?
-  user       User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, id])
   @@map("workout_logs")
 }
 
 model MobilityExercise {
-  userId         Int
-  id             Int
-  group          String
-  name           String
-  youtubeUrl     String?
-  prescription   String?
-  thumbnail      String?
-  user           User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       Int
+  id           Int
+  group        String
+  name         String
+  youtubeUrl   String?
+  prescription String?
+  thumbnail    String?
+  user         User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, id])
   @@map("mobility_exercises")
 }
 
 model MobilityLog {
-  userId         Int
-  id             Int
-  exerciseId     Int
-  exerciseName   String
-  date           DateTime
+  userId          Int
+  id              Int
+  exerciseId      Int
+  exerciseName    String
+  date            DateTime
   durationMinutes Int
-  notes          String?
-  user           User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  notes           String?
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, id])
   @@map("mobility_logs")
+}
+
+model CheckInLog {
+  userId        Int
+  id            Int
+  date          DateTime
+  createdAt     DateTime @default(now())
+  mentalState   Int
+  physicalState Int
+  mentalNotes   String?
+  physicalNotes String?
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([userId, id])
+  @@map("check_in_logs")
 }

--- a/src/app/api/athletes/[id]/check-in-logs/route.ts
+++ b/src/app/api/athletes/[id]/check-in-logs/route.ts
@@ -1,0 +1,281 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import prisma from "@/lib/prisma"
+import { getSessionUser } from "@/lib/auth"
+
+export const runtime = "nodejs"
+
+const parseId = (raw: string): number | null => {
+  const value = Number(raw)
+  return Number.isInteger(value) && value > 0 ? value : null
+}
+
+type NormalizedCheckInLog = {
+  id: number
+  date: Date
+  createdAt: Date
+  mentalState: number
+  physicalState: number
+  mentalNotes?: string
+  physicalNotes?: string
+}
+
+const toResponse = (log: {
+  id: number
+  userId: number
+  date: Date
+  createdAt: Date
+  mentalState: number
+  physicalState: number
+  mentalNotes: string | null
+  physicalNotes: string | null
+}) => ({
+  id: log.id,
+  date: log.date.toISOString().split("T")[0],
+  createdAt: log.createdAt.toISOString(),
+  mentalState: log.mentalState,
+  physicalState: log.physicalState,
+  mentalNotes: log.mentalNotes ?? undefined,
+  physicalNotes: log.physicalNotes ?? undefined,
+})
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+const normalizeCheckInLogs = (
+  value: unknown
+): { ok: true; logs: NormalizedCheckInLog[] } | { ok: false; error: string } => {
+  if (!Array.isArray(value)) {
+    return { ok: false, error: "checkInLogs must be an array." }
+  }
+
+  if (value.length > 200) {
+    return { ok: false, error: "Too many check-in logs provided." }
+  }
+
+  const logs: NormalizedCheckInLog[] = []
+  const seenIds = new Set<number>()
+
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      return { ok: false, error: "Invalid check-in log entry." }
+    }
+
+    const record = item as Record<string, unknown>
+
+    const idNumber = toNumber(record.id)
+    if (idNumber == null || !Number.isInteger(idNumber) || idNumber <= 0) {
+      return { ok: false, error: "Check-in log id must be a positive integer." }
+    }
+    if (seenIds.has(idNumber)) {
+      return { ok: false, error: "Duplicate check-in log id detected." }
+    }
+    seenIds.add(idNumber)
+
+    if (typeof record.date !== "string" || !record.date.trim()) {
+      return { ok: false, error: "Check-in log date is required." }
+    }
+    const dateValue = record.date.trim()
+    const date = new Date(`${dateValue}T00:00:00.000Z`)
+    if (Number.isNaN(date.getTime())) {
+      return { ok: false, error: "Check-in log date is invalid." }
+    }
+
+    if (typeof record.createdAt !== "string" || !record.createdAt.trim()) {
+      return { ok: false, error: "Check-in log createdAt is required." }
+    }
+    const createdAt = new Date(record.createdAt)
+    if (Number.isNaN(createdAt.getTime())) {
+      return { ok: false, error: "Check-in log createdAt is invalid." }
+    }
+
+    const mentalStateNumber = toNumber(record.mentalState)
+    if (mentalStateNumber == null || !Number.isFinite(mentalStateNumber)) {
+      return { ok: false, error: "Check-in log mentalState is required." }
+    }
+    const mentalState = Math.round(mentalStateNumber)
+    if (mentalState < 1 || mentalState > 10) {
+      return { ok: false, error: "Check-in log mentalState must be between 1 and 10." }
+    }
+
+    const physicalStateNumber = toNumber(record.physicalState)
+    if (physicalStateNumber == null || !Number.isFinite(physicalStateNumber)) {
+      return { ok: false, error: "Check-in log physicalState is required." }
+    }
+    const physicalState = Math.round(physicalStateNumber)
+    if (physicalState < 1 || physicalState > 10) {
+      return { ok: false, error: "Check-in log physicalState must be between 1 and 10." }
+    }
+
+    const mentalNotes =
+      typeof record.mentalNotes === "string" && record.mentalNotes.trim()
+        ? record.mentalNotes.trim()
+        : undefined
+    const physicalNotes =
+      typeof record.physicalNotes === "string" && record.physicalNotes.trim()
+        ? record.physicalNotes.trim()
+        : undefined
+
+    logs.push({
+      id: idNumber,
+      date,
+      createdAt,
+      mentalState,
+      physicalState,
+      mentalNotes,
+      physicalNotes,
+    })
+  }
+
+  return { ok: true, logs }
+}
+
+async function ensureAuthorized(athleteId: number) {
+  const user = await getSessionUser()
+  if (!user) {
+    return {
+      ok: false as const,
+      res: NextResponse.json({ error: "Not authenticated." }, { status: 401 }),
+    }
+  }
+
+  if (String(user.role) === "ATHLETE" && user.id !== athleteId) {
+    return {
+      ok: false as const,
+      res: NextResponse.json({ error: "Forbidden." }, { status: 403 }),
+    }
+  }
+
+  return { ok: true as const, user }
+}
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params
+  const athleteId = parseId(id)
+  if (!athleteId) {
+    return NextResponse.json({ error: "Invalid athlete id." }, { status: 400 })
+  }
+
+  const auth = await ensureAuthorized(athleteId)
+  if (!auth.ok) return auth.res
+
+  const logs = await prisma.checkInLog.findMany({
+    where: { userId: athleteId },
+    orderBy: [{ date: "desc" }, { createdAt: "desc" }, { id: "desc" }],
+  })
+
+  return NextResponse.json({ checkInLogs: logs.map(toResponse) })
+}
+
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params
+  const athleteId = parseId(id)
+  if (!athleteId) {
+    return NextResponse.json({ error: "Invalid athlete id." }, { status: 400 })
+  }
+
+  const auth = await ensureAuthorized(athleteId)
+  if (!auth.ok) return auth.res
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload." }, { status: 400 })
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid payload." }, { status: 400 })
+  }
+
+  const payload = body as { checkInLogs?: unknown }
+
+  if (!Object.prototype.hasOwnProperty.call(payload, "checkInLogs")) {
+    return NextResponse.json({ error: "checkInLogs is required." }, { status: 400 })
+  }
+
+  const normalized = normalizeCheckInLogs(payload.checkInLogs)
+  if (!normalized.ok) {
+    return NextResponse.json({ error: normalized.error }, { status: 400 })
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      const existing = await tx.checkInLog.findMany({
+        where: { userId: athleteId },
+        select: { id: true },
+      })
+
+      const incomingIds = new Set(normalized.logs.map((log) => log.id))
+      const idsToDelete = existing
+        .map((entry) => entry.id)
+        .filter((entryId) => !incomingIds.has(entryId))
+
+      if (idsToDelete.length > 0) {
+        await tx.checkInLog.deleteMany({
+          where: {
+            userId: athleteId,
+            id: { in: idsToDelete },
+          },
+        })
+      }
+
+      for (const log of normalized.logs) {
+        await tx.checkInLog.upsert({
+          where: {
+            userId_id: {
+              userId: athleteId,
+              id: log.id,
+            },
+          },
+          update: {
+            date: log.date,
+            createdAt: log.createdAt,
+            mentalState: log.mentalState,
+            physicalState: log.physicalState,
+            mentalNotes: log.mentalNotes ?? null,
+            physicalNotes: log.physicalNotes ?? null,
+          },
+          create: {
+            userId: athleteId,
+            id: log.id,
+            date: log.date,
+            createdAt: log.createdAt,
+            mentalState: log.mentalState,
+            physicalState: log.physicalState,
+            mentalNotes: log.mentalNotes ?? null,
+            physicalNotes: log.physicalNotes ?? null,
+          },
+        })
+      }
+
+      if (normalized.logs.length === 0) {
+        await tx.checkInLog.deleteMany({ where: { userId: athleteId } })
+      }
+    })
+
+    const updated = await prisma.checkInLog.findMany({
+      where: { userId: athleteId },
+      orderBy: [{ date: "desc" }, { createdAt: "desc" }, { id: "desc" }],
+    })
+
+    return NextResponse.json({ checkInLogs: updated.map(toResponse) })
+  } catch (error) {
+    console.error("Failed to persist check-in logs", error)
+    return NextResponse.json({ error: "Unable to save check-in logs." }, { status: 500 })
+  }
+}

--- a/src/lib/initial-data.ts
+++ b/src/lib/initial-data.ts
@@ -4,6 +4,7 @@ import type {
   MealLog,
   MobilityExercise,
   MobilityLog,
+  CheckInLog,
 } from "./role-types"
 
 export const initialHydrationLogs: HydrationLog[] = [
@@ -143,6 +144,8 @@ export const initialMobilityLogs: MobilityLog[] = [
   },
 ]
 
+export const initialCheckInLogs: CheckInLog[] = []
+
 export const initialAthletes: Athlete[] = [
   {
     id: 1,
@@ -191,6 +194,7 @@ export const initialAthletes: Athlete[] = [
     mealLogs: initialMealLogs,
     mobilityExercises: initialMobilityExercises,
     mobilityLogs: initialMobilityLogs,
+    checkInLogs: initialCheckInLogs,
     nutritionGoals: {
       hydrationOuncesPerDay: 110,
       caloriesPerDay: 2800,

--- a/src/lib/role-types.ts
+++ b/src/lib/role-types.ts
@@ -53,6 +53,16 @@ export type MobilityLog = {
   notes?: string
 }
 
+export type CheckInLog = {
+  id: number
+  date: string
+  createdAt: string
+  mentalState: number
+  physicalState: number
+  mentalNotes?: string
+  physicalNotes?: string
+}
+
 export type Session = {
   id: number
   type: string
@@ -100,6 +110,7 @@ export type Athlete = {
   mealLogs: MealLog[]
   mobilityExercises: MobilityExercise[]
   mobilityLogs: MobilityLog[]
+  checkInLogs: CheckInLog[]
   nutritionGoals?: NutritionGoals
   coachEmail?: string
   position?: string


### PR DESCRIPTION
## Summary
- add a Prisma CheckInLog model and REST endpoint to fetch and store athlete diary entries
- hydrate and sync check-in logs through the role context, including new update helpers
- update the dashboard check-in experience to use server-backed logs with a local fallback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fc435518a88323bac7774ed23b16d8