### PR TITLE
Ensure coaches start with no seed athletes

### DIFF
--- a/src/components/role-context.tsx
+++ b/src/components/role-context.tsx
@@ -807,6 +807,35 @@ export function RoleProvider({ children }: { children: React.ReactNode }) {
   }, [sqlAuthEnabled, isHydrated])
 
   useEffect(() => {
+    if (sqlAuthEnabled || !isHydrated) return
+
+    if (role === "coach") {
+      const managedAthletes = athletes.filter((athlete) => !athlete.isSeedData)
+      if (managedAthletes.length !== athletes.length) {
+        setAthletes(managedAthletes)
+      }
+
+      const nextActiveId = managedAthletes.some((athlete) => athlete.id === activeAthleteId)
+        ? activeAthleteId
+        : managedAthletes[0]?.id ?? null
+
+      if (nextActiveId !== activeAthleteId) {
+        setActiveAthleteId(nextActiveId)
+      }
+
+      return
+    }
+
+    if (role === "athlete" && athletes.length === 0) {
+      setAthletes(initialAthletes)
+      const nextActiveId = initialAthletes[0]?.id ?? null
+      if (nextActiveId !== activeAthleteId) {
+        setActiveAthleteId(nextActiveId)
+      }
+    }
+  }, [role, sqlAuthEnabled, isHydrated, athletes, activeAthleteId])
+
+  useEffect(() => {
     if (!sqlAuthEnabled) return
 
     let cancelled = false

--- a/src/snapshots/sql-auth/role-context.tsx
+++ b/src/snapshots/sql-auth/role-context.tsx
@@ -311,6 +311,35 @@ export function RoleProvider({ children }: { children: React.ReactNode }) {
     }
   }, [isHydrated])
 
+  useEffect(() => {
+    if (!isHydrated) return
+
+    if (role === "coach") {
+      const managedAthletes = athletes.filter((athlete) => !athlete.isSeedData)
+      if (managedAthletes.length !== athletes.length) {
+        setAthletes(managedAthletes)
+      }
+
+      const nextActiveId = managedAthletes.some((athlete) => athlete.id === activeAthleteId)
+        ? activeAthleteId
+        : managedAthletes[0]?.id ?? null
+
+      if (nextActiveId !== activeAthleteId) {
+        setActiveAthleteId(nextActiveId)
+      }
+
+      return
+    }
+
+    if (role === "athlete" && athletes.length === 0) {
+      setAthletes(initialAthletes)
+      const nextActiveId = initialAthletes[0]?.id ?? null
+      if (nextActiveId !== activeAthleteId) {
+        setActiveAthleteId(nextActiveId)
+      }
+    }
+  }, [role, isHydrated, athletes, activeAthleteId])
+
   const setRole = useCallback((nextRole: Role) => {
     setRoleState(nextRole)
   }, [])


### PR DESCRIPTION
## Summary
- ensure coaches no longer see seed athletes by default and keep their athlete list empty until they add someone
- restore sample seed athletes when switching back to the athlete role with no managed athletes
- update the role-context snapshot to reflect the new behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd2fa91fc88323b68c143f209539ed