### PR TITLE
Improve dashboard mobile spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,7 +62,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-gradient-to-br from-[#f0f4fa] via-[#d7e3f5] to-[#b7c8e5] text-foreground antialiased;
+    @apply bg-gradient-to-br from-[#f0f4fa] via-[#d7e3f5] to-[#b7c8e5] text-foreground antialiased overflow-x-hidden sm:overflow-x-visible;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
             <Navigation />
             <main className="lg:pl-80">
               <div className="py-6">
-                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                <div className="mx-auto max-w-7xl px-3 sm:px-6 lg:px-8">
                   {children}
                 </div>
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -589,11 +589,11 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-6">
         {/* Daily Check-in Card */}
-        <Card className="mb-12 glass-card border-0 shadow-premium-lg">
-          <CardHeader className="pb-6">
-            <CardTitle className="flex items-center gap-4 text-2xl text-gray-900">
+        <Card className="mb-10 sm:mb-12 glass-card border-0 shadow-premium-lg">
+          <CardHeader className="pb-5 sm:pb-6">
+            <CardTitle className="flex items-center gap-3 sm:gap-4 text-2xl text-gray-900">
               <div className="w-12 h-12 rounded-2xl gradient-primary flex items-center justify-center shadow-glow">
                 <Target className="h-7 w-7 text-white" />
               </div>
@@ -607,8 +607,8 @@ export default function DashboardPage() {
             </CardTitle>
             <p className="text-gray-600 text-lg">How are you feeling today? Rate your mental and physical state.</p>
           </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <CardContent className="space-y-5 sm:space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
               <NumberScale
                 label="Mental State"
                 value={mentalState}
@@ -620,7 +620,7 @@ export default function DashboardPage() {
                 onChange={setPhysicalState}
               />
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <p className="text-sm font-semibold text-gray-600">Mental Notes</p>
@@ -630,7 +630,7 @@ export default function DashboardPage() {
                   value={mentalNotes}
                   onChange={(event) => setMentalNotes(event.target.value)}
                   placeholder="Celebrate wins, note stressors, or reflect on your mindset."
-                  className="w-full min-h-[120px] rounded-2xl border border-white/30 bg-white/60 px-4 py-3 text-sm text-gray-700 shadow-inner backdrop-blur-sm transition focus:border-[#1c6dd0] focus:outline-none focus:ring-2 focus:ring-[#1c6dd0]/50"
+                  className="w-full min-h-[120px] rounded-2xl border border-white/30 bg-white/60 px-3 py-2.5 text-sm text-gray-700 shadow-inner backdrop-blur-sm transition focus:border-[#1c6dd0] focus:outline-none focus:ring-2 focus:ring-[#1c6dd0]/50 sm:px-4 sm:py-3"
                 />
               </div>
               <div className="space-y-2">
@@ -642,7 +642,7 @@ export default function DashboardPage() {
                   value={physicalNotes}
                   onChange={(event) => setPhysicalNotes(event.target.value)}
                   placeholder="Log soreness, recovery cues, or anything your body is telling you."
-                  className="w-full min-h-[120px] rounded-2xl border border-white/30 bg-white/60 px-4 py-3 text-sm text-gray-700 shadow-inner backdrop-blur-sm transition focus:border-[#1c6dd0] focus:outline-none focus:ring-2 focus:ring-[#1c6dd0]/50"
+                  className="w-full min-h-[120px] rounded-2xl border border-white/30 bg-white/60 px-3 py-2.5 text-sm text-gray-700 shadow-inner backdrop-blur-sm transition focus:border-[#1c6dd0] focus:outline-none focus:ring-2 focus:ring-[#1c6dd0]/50 sm:px-4 sm:py-3"
                 />
               </div>
             </div>
@@ -652,7 +652,7 @@ export default function DashboardPage() {
             <Button
               onClick={handleCheckIn}
               disabled={mentalState === null || physicalState === null}
-              className="w-full h-14 text-lg font-bold gradient-primary hover:shadow-glow text-white border-0 rounded-2xl transition-all duration-300 hover:scale-105"
+              className="w-full h-12 text-base font-bold gradient-primary hover:shadow-glow text-white border-0 rounded-2xl transition-all duration-300 hover:scale-105 sm:h-14 sm:text-lg"
             >
               {checkInCompleted ? (
                 <>
@@ -671,11 +671,11 @@ export default function DashboardPage() {
                 <h4 className="text-lg font-semibold text-gray-800 mb-4">
                   Recent check-in notes
                 </h4>
-                <div className="space-y-4 max-h-64 overflow-y-auto pr-1">
+                <div className="space-y-3 sm:space-y-4 max-h-64 overflow-y-auto pr-1">
                   {recentDiaryEntries.map((entry) => (
                     <div
                       key={entry.createdAt}
-                      className="glass-card border border-white/30 rounded-2xl p-4 space-y-3 shadow-sm"
+                      className="glass-card border border-white/30 rounded-2xl p-3 sm:p-4 space-y-3 shadow-sm"
                     >
                       <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-gray-600">
                         <span className="font-semibold text-gray-800">
@@ -719,23 +719,23 @@ export default function DashboardPage() {
         </Card>
 
         {/* Today's Progress & Upcoming */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12">
-          <div className="space-y-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-5 sm:gap-6 lg:gap-8 mb-10 sm:mb-12">
+          <div className="space-y-5 sm:space-y-6">
             <h3 className="text-2xl font-bold text-gray-900 flex items-center gap-3">
               <Zap className="h-6 w-6 text-[#0f4d92]" />
               Today&apos;s Progress
             </h3>
-            
+
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300">
-              <CardContent className="p-6">
+              <CardContent className="p-4 sm:p-6">
                 <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4">
+                  <div className="flex items-center gap-3 sm:gap-4">
                     <div className="w-14 h-14 rounded-2xl gradient-success flex items-center justify-center shadow-glow">
                       <Droplets className="h-7 w-7 text-white" />
                     </div>
                     <div>
                       <p className="text-sm font-semibold text-gray-600">Hydration</p>
-                    <p className="text-3xl font-bold text-gray-900">{hydrationStats.total}oz</p>
+                      <p className="text-3xl font-bold text-gray-900">{hydrationStats.total}oz</p>
                     </div>
                   </div>
                   <div className="text-right">
@@ -747,8 +747,8 @@ export default function DashboardPage() {
             </Card>
             
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300">
-              <CardContent className="p-6">
-                <div className="flex items-center space-x-4">
+              <CardContent className="p-4 sm:p-6">
+                <div className="flex items-center gap-3 sm:gap-4">
                   <div className="w-14 h-14 rounded-2xl gradient-warning flex items-center justify-center shadow-glow">
                     <Apple className="h-7 w-7 text-white" />
                   </div>
@@ -761,8 +761,8 @@ export default function DashboardPage() {
             </Card>
             
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300">
-              <CardContent className="p-6">
-                <div className="flex items-center space-x-4">
+              <CardContent className="p-4 sm:p-6">
+                <div className="flex items-center gap-3 sm:gap-4">
                   <div className="w-14 h-14 rounded-2xl gradient-danger flex items-center justify-center shadow-glow">
                     <Dumbbell className="h-7 w-7 text-white" />
                   </div>
@@ -775,7 +775,7 @@ export default function DashboardPage() {
             </Card>
           </div>
 
-          <div className="lg:col-span-2 space-y-6">
+          <div className="lg:col-span-2 space-y-5 sm:space-y-6">
             <h3 className="text-2xl font-bold text-gray-900 flex items-center gap-3">
               <Calendar className="h-6 w-6 text-[#0f4d92]" />
               Upcoming
@@ -788,14 +788,14 @@ export default function DashboardPage() {
                   Academics Due
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-3 sm:space-y-4">
                 {upcomingItems.length > 0 ? (
                   upcomingItems.map((item) => (
                     <div
                       key={item.id}
-                      className="flex items-center justify-between p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
+                      className="flex items-center justify-between p-4 sm:p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
                     >
-                      <div className="flex items-center space-x-4">
+                      <div className="flex items-center gap-3 sm:gap-4">
                         <div className="w-12 h-12 rounded-xl gradient-primary flex items-center justify-center">
                           <BookOpen className="h-6 w-6 text-white" />
                         </div>
@@ -805,14 +805,14 @@ export default function DashboardPage() {
                           <Progress value={item.progress} className="w-32 h-2 mt-2" />
                         </div>
                       </div>
-                      <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-2 sm:gap-3">
                         {getPriorityBadge(item.priority)}
                         <span className="text-sm text-gray-500 font-medium">{item.due}</span>
                       </div>
                     </div>
                   ))
                 ) : (
-                  <div className="p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
+                  <div className="p-4 sm:p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
                     You&apos;re all caught up on academic work.
                   </div>
                 )}
@@ -829,14 +829,14 @@ export default function DashboardPage() {
                   Today&apos;s Training
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-3 sm:space-y-4">
                 {todaysSessions.length > 0 ? (
                   todaysSessions.map((session) => (
                     <div
                       key={session.id}
-                      className="flex items-center justify-between p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
+                      className="flex items-center justify-between p-4 sm:p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
                     >
-                      <div className="flex items-center space-x-4">
+                      <div className="flex items-center gap-3 sm:gap-4">
                         <div
                           className={cn(
                             "w-12 h-12 rounded-xl flex items-center justify-center",
@@ -853,7 +853,7 @@ export default function DashboardPage() {
                         <div>
                           <p className="font-bold text-gray-900">{session.title}</p>
                           <p className="text-sm text-gray-600">{formatSessionTimeRange(session.startAt, session.endAt)}</p>
-                          <div className="flex flex-wrap items-center gap-4 mt-1 text-xs text-gray-500">
+                          <div className="flex flex-wrap items-center gap-3 sm:gap-4 mt-1 text-xs text-gray-500">
                             {session.focus && <span>{session.focus}</span>}
                             {session.assignedBy && <span>By {session.assignedBy}</span>}
                           </div>
@@ -863,7 +863,7 @@ export default function DashboardPage() {
                     </div>
                   ))
                 ) : (
-                  <div className="p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
+                  <div className="p-4 sm:p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
                     No training sessions scheduled for today yet.
                   </div>
                 )}
@@ -876,12 +876,12 @@ export default function DashboardPage() {
                   Personal Calendar
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-3 sm:space-y-4">
                 {upcomingCalendar.length > 0 ? (
                   upcomingCalendar.map((event) => (
                     <div
                       key={event.id}
-                      className="flex items-center justify-between p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
+                      className="flex items-center justify-between p-4 sm:p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
                     >
                       <div>
                         <p className="font-bold text-gray-900">{event.title}</p>
@@ -894,7 +894,7 @@ export default function DashboardPage() {
                     </div>
                   ))
                 ) : (
-                  <div className="p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
+                  <div className="p-4 sm:p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
                     No upcoming events on the calendar.
                   </div>
                 )}
@@ -907,12 +907,12 @@ export default function DashboardPage() {
                   Workout Assignments
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-3 sm:space-y-4">
                 {workoutAssignments.length > 0 ? (
                   workoutAssignments.map((workout) => (
                     <div
                       key={workout.id}
-                      className="flex items-center justify-between p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
+                      className="flex items-center justify-between p-4 sm:p-5 rounded-2xl glass-card border border-white/20 hover:bg-white/50 transition-all duration-300"
                     >
                       <div>
                         <p className="font-bold text-gray-900">{workout.title}</p>
@@ -936,7 +936,7 @@ export default function DashboardPage() {
                     </div>
                   ))
                 ) : (
-                  <div className="p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
+                  <div className="p-4 sm:p-6 text-center rounded-2xl border border-dashed border-gray-300 bg-white/60 text-sm text-gray-500">
                     No workouts assigned yet. Your coach will add them here.
                   </div>
                 )}
@@ -946,8 +946,8 @@ export default function DashboardPage() {
         </div>
 
         {/* This Week Stats */}
-        <div className="mb-12">
-          <div className="flex items-center justify-between mb-8">
+        <div className="mb-10 sm:mb-12">
+          <div className="flex items-center justify-between mb-6 sm:mb-8">
             <h3 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
               This Week
             </h3>
@@ -955,9 +955,9 @@ export default function DashboardPage() {
               View details <ArrowRight className="h-4 w-4 ml-2" />
             </Button>
           </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6">
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
-              <CardContent className="p-6 text-center">
+              <CardContent className="p-4 sm:p-6 text-center">
                 <div className="w-16 h-16 rounded-2xl gradient-primary flex items-center justify-center mx-auto mb-4 shadow-glow">
                   <Dumbbell className="h-8 w-8 text-white" />
                 </div>
@@ -967,7 +967,7 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
-              <CardContent className="p-6 text-center">
+              <CardContent className="p-4 sm:p-6 text-center">
                 <div className="w-16 h-16 rounded-2xl gradient-warning flex items-center justify-center mx-auto mb-4 shadow-glow">
                   <Award className="h-8 w-8 text-white" />
                 </div>
@@ -977,7 +977,7 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
-              <CardContent className="p-6 text-center">
+              <CardContent className="p-4 sm:p-6 text-center">
                 <div className="w-16 h-16 rounded-2xl gradient-success flex items-center justify-center mx-auto mb-4 shadow-glow">
                   <Droplets className="h-8 w-8 text-white" />
                 </div>
@@ -987,7 +987,7 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
             <Card className="glass-card border-0 shadow-premium hover:shadow-glow transition-all duration-300 hover:scale-105">
-              <CardContent className="p-6 text-center">
+              <CardContent className="p-4 sm:p-6 text-center">
                 <div className="w-16 h-16 rounded-2xl gradient-secondary flex items-center justify-center mx-auto mb-4 shadow-glow">
                   <BookOpen className="h-8 w-8 text-white" />
                 </div>

--- a/src/components/number-scale.tsx
+++ b/src/components/number-scale.tsx
@@ -12,16 +12,16 @@ interface NumberScaleProps {
 
 export function NumberScale({ value, onChange, label, className }: NumberScaleProps) {
   return (
-    <div className={cn("space-y-4", className)}>
+    <div className={cn("space-y-3 sm:space-y-4", className)}>
       <h3 className="text-base font-semibold text-gray-800">{label}</h3>
-      <div className="flex gap-2 justify-center">
+      <div className="flex flex-wrap justify-center gap-2 sm:gap-3">
         {[1, 2, 3, 4, 5].map((num) => (
           <Button
             key={num}
             variant={value === num ? "default" : "outline"}
             size="sm"
             className={cn(
-              "h-12 w-12 rounded-xl text-lg font-bold transition-all duration-300 relative overflow-hidden",
+              "h-10 w-10 rounded-xl text-base font-bold transition-all duration-300 relative overflow-hidden sm:h-11 sm:w-11 sm:text-lg",
               value === num
                 ? "gradient-primary text-white shadow-glow scale-105 border-0"
                 : "glass-card border-white/20 hover:bg-white/50 hover:scale-105 text-gray-700 hover:text-gray-900"


### PR DESCRIPTION
## Summary
- tighten dashboard layout padding and card spacing for smaller viewports
- update number scale buttons to wrap and resize on compact screens
- hide horizontal overflow on mobile to prevent stray scrolling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fd7260ce8c83239e64ea5dcec92708