### PR TITLE
Adjust mobility stats layout for mobile

### DIFF
--- a/src/app/mobility/page.tsx
+++ b/src/app/mobility/page.tsx
@@ -323,7 +323,7 @@ export default function Mobility() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <Card>
           <CardContent className="p-3 sm:p-4">
             <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- update the mobility stats card grid to show two columns on mobile like other sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe83b743ec83238fdb6dead9fc4911