### PR TITLE
Expand schedule preview tag coverage

### DIFF
--- a/src/components/coach-dashboard.tsx
+++ b/src/components/coach-dashboard.tsx
@@ -71,7 +71,19 @@ const formatDateForInput = (date: Date) => {
   return `${year}-${month}-${day}`
 }
 
-const targetedScheduleTags = new Set(["main group", "main-group", "multi", "multis", "pv", "hj"])
+const targetedScheduleTags = new Set([
+  "main group",
+  "main-group",
+  "multi",
+  "multis",
+  "pv",
+  "hj",
+  "men",
+  "women",
+  "lift",
+  "100mh",
+  "400mh",
+])
 
 const resolveScheduleTags = (group: string) => {
   const normalized = group.toLowerCase()


### PR DESCRIPTION
## Summary
- expand the set of targeted schedule tags so that preview generation includes men, women, lift, 100mh, and 400mh groupings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fec22f02908323aa38d78b0c70de68