### PR TITLE
Allow table cells to wrap to improve schedule parser layout

### DIFF
--- a/src/app/fuel/page.tsx
+++ b/src/app/fuel/page.tsx
@@ -1361,7 +1361,7 @@ export default function Fuel() {
                         <TableCell>{formatMealDate(meal.dateTime)}</TableCell>
                         <TableCell>{meal.calories}</TableCell>
                         <TableCell>{formatTwoDecimalString(meal.proteinG)}g</TableCell>
-                        <TableCell className="max-w-xs truncate">{meal.notes}</TableCell>
+                        <TableCell className="max-w-xs truncate whitespace-nowrap">{meal.notes}</TableCell>
                         <TableCell>
                           <Badge variant={meal.completed ? "default" : "secondary"}>
                             {meal.completed ? "Completed" : "Planned"}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,10 +6,7 @@ import { cn } from "@/lib/utils"
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}
@@ -70,7 +67,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-10 px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}
@@ -83,7 +80,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- allow table headers and cells to wrap so schedule parser previews no longer overflow horizontally
- keep meal log note truncation by explicitly applying whitespace control where needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fed1dc0ef48323ab86dd495642d296