### PR TITLE
Fix training plan bullet stripping in coach schedule parser

### DIFF
--- a/src/lib/schedule-parser.ts
+++ b/src/lib/schedule-parser.ts
@@ -190,6 +190,25 @@ const parsePracticeSchedule = (
   return sessions
 }
 
+const stripLeadingListMarker = (value: string) => {
+  let result = value
+
+  // Remove repeated bullet characters (e.g., -, –, •)
+  result = result.replace(/^(?:[-–—•·]\s*)+/, "")
+
+  const orderedMatch = result.match(/^\d+[.)]\s*/)
+  if (orderedMatch) {
+    return result.slice(orderedMatch[0].length)
+  }
+
+  const alphaMatch = result.match(/^[a-zA-Z][.)]\s*/)
+  if (alphaMatch) {
+    return result.slice(alphaMatch[0].length)
+  }
+
+  return result
+}
+
 const parseTrainingPlan = (lines: string[]) => {
   const notes: Record<string, string[]> = {}
   let currentDay: string | null = null
@@ -209,7 +228,7 @@ const parseTrainingPlan = (lines: string[]) => {
 
     if (!currentDay) continue
 
-    const cleaned = trimmed.replace(/^[-•\d.)\s]+/, "").trim()
+    const cleaned = stripLeadingListMarker(trimmed).trim()
     if (!cleaned) continue
 
     notes[currentDay].push(cleaned)


### PR DESCRIPTION
## Summary
- add a helper that strips only list markers from training plan lines
- preserve numeric prefixes like 3x60m when parsing training plan notes
- reuse the helper when building training plan notes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fed4007fa4832397a80ab53a48bb2a