### PR TITLE
Condense parsed schedule text in coach dashboard

### DIFF
--- a/src/components/coach-dashboard.tsx
+++ b/src/components/coach-dashboard.tsx
@@ -992,10 +992,24 @@ export function CoachDashboard() {
                                   ))}
                                 </TableCell>
                                 <TableCell className="text-xs font-medium text-gray-700 sm:text-sm">
-                                  {session.title}
+                                  <span className="block max-w-[12rem] truncate sm:max-w-[16rem]">
+                                    {session.title}
+                                  </span>
                                 </TableCell>
-                                <TableCell className="whitespace-pre-line text-xs text-gray-600 sm:text-sm">
-                                  {session.notes ?? "—"}
+                                <TableCell className="text-xs text-gray-600 sm:text-sm">
+                                  <span
+                                    className="block max-w-[14rem] sm:max-w-[18rem]"
+                                    style={{
+                                      display: "-webkit-box",
+                                      WebkitLineClamp: 3,
+                                      WebkitBoxOrient: "vertical",
+                                      overflow: "hidden",
+                                      textOverflow: "ellipsis",
+                                      whiteSpace: "pre-line",
+                                    }}
+                                  >
+                                    {session.notes ?? "—"}
+                                  </span>
                                 </TableCell>
                               </TableRow>
                             )


### PR DESCRIPTION
## Summary
- truncate parsed session titles in the coach dashboard schedule table
- clamp parsed session notes to three lines with an ellipsis to avoid oversized rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fed65241a8832399d2fbfbb6b809b6