### PR TITLE
Add hurdle group support to coach schedule parser

### DIFF
--- a/src/components/coach-dashboard.tsx
+++ b/src/components/coach-dashboard.tsx
@@ -140,11 +140,22 @@ const getDefaultWeekStartDate = () => {
   return toDateInputValue(monday)
 }
 
-const formatTagLabel = (value: string) =>
-  value
+const SPECIAL_TAG_LABELS: Record<string, string> = {
+  "100mh": "100mH",
+  "400mh": "400mH",
+}
+
+const formatTagLabel = (value: string) => {
+  const lower = value.toLowerCase()
+  if (SPECIAL_TAG_LABELS[lower]) {
+    return SPECIAL_TAG_LABELS[lower]
+  }
+
+  return value
     .split(" ")
     .map((part) => (part ? part[0]?.toUpperCase() + part.slice(1) : ""))
     .join(" ")
+}
 
 function CoachAthleteCard({
   athleteId,


### PR DESCRIPTION
## Summary
- normalize coach schedule tags to recognize 100mH and 400mH groups
- filter training plan notes containing hurdle references from shared session descriptions
- display friendly labels for the new hurdle tags in the coach dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68feea16c1688323a3f96235215a1182