### PR TITLE
Add delete control to training session editor

### DIFF
--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -23,7 +23,8 @@ import {
   Timer,
   ChevronDown,
   ChevronUp,
-  Pencil
+  Pencil,
+  Trash
 } from "lucide-react"
 
 const mockPRs = [
@@ -89,7 +90,7 @@ const emptySessionForm = {
 }
 
 export default function Training() {
-  const { role, primaryAthlete, scheduleSession, toggleSessionCompletion, currentUser, updateSession } = useRole()
+  const { role, primaryAthlete, scheduleSession, toggleSessionCompletion, currentUser, updateSession, deleteSession } = useRole()
   const sessions = primaryAthlete?.sessions ?? []
   const [prs, setPRs] = useState(currentUser ? [] : mockPRs)
   const [isAddSessionOpen, setIsAddSessionOpen] = useState(false)
@@ -146,6 +147,15 @@ export default function Training() {
       notes: editingSession.notes,
     })
 
+    setIsEditSessionOpen(false)
+    setEditingSessionId(null)
+    setEditingSession(() => ({ ...emptySessionForm }))
+  }
+
+  const handleDeleteSession = () => {
+    if (!primaryAthlete || editingSessionId == null) return
+
+    deleteSession(primaryAthlete.id, editingSessionId)
     setIsEditSessionOpen(false)
     setEditingSessionId(null)
     setEditingSession(() => ({ ...emptySessionForm }))
@@ -372,9 +382,19 @@ export default function Training() {
                     placeholder="Session notes"
                   />
                 </div>
-                <Button onClick={handleUpdateSession} className="w-full">
-                  Save Changes
-                </Button>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button onClick={handleUpdateSession} className="w-full sm:flex-1">
+                    Save Changes
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={handleDeleteSession}
+                    className="w-full sm:w-auto"
+                  >
+                    <Trash className="mr-2 h-4 w-4" /> Delete Session
+                  </Button>
+                </div>
               </div>
             </DialogContent>
           </Dialog>

--- a/src/components/role-context.tsx
+++ b/src/components/role-context.tsx
@@ -588,6 +588,7 @@ type RoleContextValue = {
     session: ScheduleSessionInput,
     options?: ScheduleOptions
   ) => void
+  deleteSession: (athleteId: number, sessionId: number) => void
   toggleSessionCompletion: (athleteId: number, sessionId: number) => void
   addAthlete: (input: AddAthleteInput) => void
   assignSessionToTag: (tag: string, session: ScheduleSessionInput, options?: ScheduleOptions) => void
@@ -1517,6 +1518,34 @@ export function RoleProvider({ children }: { children: React.ReactNode }) {
     [applySessionToAthlete, syncWorkoutsToServer]
   )
 
+  const deleteSession = useCallback(
+    (athleteId: number, sessionId: number) => {
+      let updatedWorkouts: WorkoutPlan[] | null = null
+      setAthletes((prev) =>
+        prev.map((athlete): Athlete => {
+          if (athlete.id !== athleteId) return athlete
+
+          const nextSessions = athlete.sessions.filter((session) => session.id !== sessionId)
+          const nextCalendar = athlete.calendar.filter((event) => event.id !== sessionId)
+          const nextWorkouts = athlete.workouts.filter((workout) => workout.id !== sessionId)
+          updatedWorkouts = nextWorkouts
+
+          return {
+            ...athlete,
+            sessions: nextSessions,
+            calendar: nextCalendar,
+            workouts: nextWorkouts,
+          }
+        })
+      )
+
+      if (updatedWorkouts) {
+        void syncWorkoutsToServer(athleteId, updatedWorkouts)
+      }
+    },
+    [syncWorkoutsToServer]
+  )
+
   const toggleSessionCompletion = useCallback((athleteId: number, sessionId: number) => {
     let updatedWorkouts: WorkoutPlan[] | null = null
     setAthletes((prev) =>
@@ -2377,6 +2406,7 @@ export function RoleProvider({ children }: { children: React.ReactNode }) {
       setActiveAthleteId,
       scheduleSession,
       updateSession,
+      deleteSession,
       toggleSessionCompletion,
       addAthlete,
       assignSessionToTag,
@@ -2402,6 +2432,7 @@ export function RoleProvider({ children }: { children: React.ReactNode }) {
       activeAthleteId,
       scheduleSession,
       updateSession,
+      deleteSession,
       toggleSessionCompletion,
       addAthlete,
       assignSessionToTag,


### PR DESCRIPTION
## Summary
- add a deleteSession helper to the role context so sessions are removed from workouts and calendars
- surface a delete button in the training session edit dialog that calls the new helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69069b9f2e2c8323b3dca6127e6676fe