### PR TITLE
Allow scheduling sessions without end time

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -59,14 +59,18 @@ const formatTwoDecimalString = (value: number): string => {
 }
 
 const formatTimeRange = (start?: string, end?: string) => {
-  if (!start || !end) return ""
+  if (!start) return ""
   const startDate = new Date(start)
-  const endDate = new Date(end)
-  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) return ""
+  if (Number.isNaN(startDate.getTime())) return ""
   const formatter = new Intl.DateTimeFormat("en-US", {
     hour: "numeric",
     minute: "2-digit",
   })
+  if (!end) {
+    return formatter.format(startDate)
+  }
+  const endDate = new Date(end)
+  if (Number.isNaN(endDate.getTime())) return formatter.format(startDate)
   return `${formatter.format(startDate)} - ${formatter.format(endDate)}`
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,17 +82,23 @@ const isSameDay = (value: string, reference: Date) => {
   )
 }
 
-const formatSessionTimeRange = (startAt: string, endAt: string) => {
-  if (!startAt || !endAt) return ""
+const formatSessionTimeRange = (startAt: string, endAt?: string) => {
+  if (!startAt) return ""
   const start = new Date(startAt)
-  const end = new Date(endAt)
-  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return ""
+  if (Number.isNaN(start.getTime())) return ""
   const format = (date: Date) =>
     date.toLocaleTimeString("en-US", {
       hour: "numeric",
       minute: "2-digit",
       hour12: true,
     })
+
+  if (!endAt) {
+    return format(start)
+  }
+
+  const end = new Date(endAt)
+  if (Number.isNaN(end.getTime())) return format(start)
 
   return `${format(start)} - ${format(end)}`
 }

--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -52,9 +52,11 @@ const getTypeIcon = (type: string) => {
   }
 }
 
-const formatDuration = (startAt: string, endAt: string) => {
+const formatDuration = (startAt: string, endAt?: string) => {
+  if (!startAt || !endAt) return ""
   const start = new Date(startAt)
   const end = new Date(endAt)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return ""
   const diffMs = end.getTime() - start.getTime()
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
   const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))
@@ -84,7 +86,6 @@ const emptySessionForm = {
   type: "practice",
   title: "",
   startAt: "",
-  endAt: "",
   intensity: "medium",
   notes: "",
 }
@@ -118,12 +119,11 @@ export default function Training() {
 
   const handleAddSession = () => {
     if (!primaryAthlete) return
-    if (newSession.title && newSession.startAt && newSession.endAt) {
+    if (newSession.title && newSession.startAt) {
       scheduleSession(primaryAthlete.id, {
         type: newSession.type,
         title: newSession.title,
         startAt: newSession.startAt,
-        endAt: newSession.endAt,
         intensity: newSession.intensity,
         notes: newSession.notes,
       })
@@ -134,7 +134,7 @@ export default function Training() {
 
   const handleUpdateSession = () => {
     if (!primaryAthlete || editingSessionId == null) return
-    if (!editingSession.title || !editingSession.startAt || !editingSession.endAt) {
+    if (!editingSession.title || !editingSession.startAt) {
       return
     }
 
@@ -142,7 +142,6 @@ export default function Training() {
       type: editingSession.type,
       title: editingSession.title,
       startAt: editingSession.startAt,
-      endAt: editingSession.endAt,
       intensity: editingSession.intensity,
       notes: editingSession.notes,
     })
@@ -196,7 +195,6 @@ export default function Training() {
       type: session.type,
       title: session.title,
       startAt: toDateTimeLocalInput(session.startAt),
-      endAt: toDateTimeLocalInput(session.endAt),
       intensity: session.intensity,
       notes: session.notes ?? "",
     })
@@ -274,23 +272,13 @@ export default function Training() {
                     placeholder="Enter session title"
                   />
                 </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="text-sm font-medium">Start Time</label>
-                    <Input 
-                      type="datetime-local"
-                      value={newSession.startAt}
-                      onChange={(e) => setNewSession(prev => ({ ...prev, startAt: e.target.value }))}
-                    />
-                  </div>
-                  <div>
-                    <label className="text-sm font-medium">End Time</label>
-                    <Input 
-                      type="datetime-local"
-                      value={newSession.endAt}
-                      onChange={(e) => setNewSession(prev => ({ ...prev, endAt: e.target.value }))}
-                    />
-                  </div>
+                <div>
+                  <label className="text-sm font-medium">Start Time</label>
+                  <Input
+                    type="datetime-local"
+                    value={newSession.startAt}
+                    onChange={(e) => setNewSession(prev => ({ ...prev, startAt: e.target.value }))}
+                  />
                 </div>
                 <div>
                   <label className="text-sm font-medium">Intensity</label>
@@ -344,23 +332,13 @@ export default function Training() {
                     placeholder="Enter session title"
                   />
                 </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="text-sm font-medium">Start Time</label>
-                    <Input
-                      type="datetime-local"
-                      value={editingSession.startAt}
-                      onChange={(e) => setEditingSession(prev => ({ ...prev, startAt: e.target.value }))}
-                    />
-                  </div>
-                  <div>
-                    <label className="text-sm font-medium">End Time</label>
-                    <Input
-                      type="datetime-local"
-                      value={editingSession.endAt}
-                      onChange={(e) => setEditingSession(prev => ({ ...prev, endAt: e.target.value }))}
-                    />
-                  </div>
+                <div>
+                  <label className="text-sm font-medium">Start Time</label>
+                  <Input
+                    type="datetime-local"
+                    value={editingSession.startAt}
+                    onChange={(e) => setEditingSession(prev => ({ ...prev, startAt: e.target.value }))}
+                  />
                 </div>
                 <div>
                   <label className="text-sm font-medium">Intensity</label>
@@ -546,12 +524,16 @@ export default function Training() {
                             </span>
                             <span className="flex items-center gap-1">
                               <Clock className="h-4 w-4" />
-                              {formatTime(session.startAt)} - {formatTime(session.endAt)}
+                              {session.endAt
+                                ? `${formatTime(session.startAt)} - ${formatTime(session.endAt)}`
+                                : formatTime(session.startAt)}
                             </span>
-                            <span className="flex items-center gap-1">
-                              <Timer className="h-4 w-4" />
-                              {formatDuration(session.startAt, session.endAt)}
-                            </span>
+                            {session.endAt && (
+                              <span className="flex items-center gap-1">
+                                <Timer className="h-4 w-4" />
+                                {formatDuration(session.startAt, session.endAt)}
+                              </span>
+                            )}
                           </div>
                           {session.notes && (
                             <p className="text-sm text-muted-foreground mt-1">{session.notes}</p>
@@ -617,7 +599,9 @@ export default function Training() {
                         </TableCell>
                         <TableCell className="font-medium">{session.title}</TableCell>
                         <TableCell>{new Date(session.startAt).toLocaleDateString()}</TableCell>
-                        <TableCell>{formatDuration(session.startAt, session.endAt)}</TableCell>
+                        <TableCell>
+                          {session.endAt ? formatDuration(session.startAt, session.endAt) : "—"}
+                        </TableCell>
                         <TableCell>
                           <Badge className={getIntensityColor(session.intensity)}>
                             {session.intensity}

--- a/src/components/coach-dashboard.tsx
+++ b/src/components/coach-dashboard.tsx
@@ -35,7 +35,6 @@ type AssignExerciseForm = {
   focus: string
   date: string
   startTime: string
-  endTime: string
   intensity: string
   notes: string
 }
@@ -46,7 +45,6 @@ const initialForm: AssignExerciseForm = {
   focus: "",
   date: "",
   startTime: "",
-  endTime: "",
   intensity: "medium",
   notes: "",
 }
@@ -266,12 +264,11 @@ function CoachAthleteCard({
   }
 
   const handleAssign = () => {
-    if (!form.title || !form.date || !form.startTime || !form.endTime) {
+    if (!form.title || !form.date || !form.startTime) {
       return
     }
 
     const startAt = `${form.date}T${form.startTime}`
-    const endAt = `${form.date}T${form.endTime}`
 
     scheduleSession(
       athleteId,
@@ -279,7 +276,6 @@ function CoachAthleteCard({
         title: form.title,
         type: form.type,
         startAt,
-        endAt,
         intensity: form.intensity,
         notes: form.notes,
       },
@@ -587,23 +583,13 @@ function CoachAthleteCard({
                   </select>
                 </div>
               </div>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <div>
-                  <label className="text-xs font-medium text-gray-600">Start Time</label>
-                  <Input
-                    type="time"
-                    value={form.startTime}
-                    onChange={(event) => setForm((prev) => ({ ...prev, startTime: event.target.value }))}
-                  />
-                </div>
-                <div>
-                  <label className="text-xs font-medium text-gray-600">End Time</label>
-                  <Input
-                    type="time"
-                    value={form.endTime}
-                    onChange={(event) => setForm((prev) => ({ ...prev, endTime: event.target.value }))}
-                  />
-                </div>
+              <div>
+                <label className="text-xs font-medium text-gray-600">Start Time</label>
+                <Input
+                  type="time"
+                  value={form.startTime}
+                  onChange={(event) => setForm((prev) => ({ ...prev, startTime: event.target.value }))}
+                />
               </div>
               <div>
                 <label className="text-xs font-medium text-gray-600">Coaching Notes</label>
@@ -663,7 +649,6 @@ export function CoachDashboard() {
           focus: session.focus ?? "",
           date: toDateInputValue(session.startAt),
           startTime: toTimeInputValue(session.startAt),
-          endTime: toTimeInputValue(session.endAt),
           intensity: session.intensity,
           notes: session.notes ?? "",
         })
@@ -692,15 +677,13 @@ export function CoachDashboard() {
     if (
       !sessionEditForm.title.trim() ||
       !sessionEditForm.date ||
-      !sessionEditForm.startTime ||
-      !sessionEditForm.endTime
+      !sessionEditForm.startTime
     ) {
-      setSessionEditError("Title, date, start time, and end time are required.")
+      setSessionEditError("Title, date, and start time are required.")
       return
     }
 
     const startAt = `${sessionEditForm.date}T${sessionEditForm.startTime}`
-    const endAt = `${sessionEditForm.date}T${sessionEditForm.endTime}`
 
     updateSession(
       sessionEditState.athleteId,
@@ -709,7 +692,6 @@ export function CoachDashboard() {
         title: sessionEditForm.title,
         type: sessionEditForm.type,
         startAt,
-        endAt,
         intensity: sessionEditForm.intensity,
         notes: sessionEditForm.notes,
       },
@@ -811,8 +793,8 @@ export function CoachDashboard() {
       return
     }
 
-    if (!bulkAssignForm.title || !bulkAssignForm.date || !bulkAssignForm.startTime || !bulkAssignForm.endTime) {
-      setBulkAssignError("Title, date, start time, and end time are required.")
+    if (!bulkAssignForm.title || !bulkAssignForm.date || !bulkAssignForm.startTime) {
+      setBulkAssignError("Title, date, and start time are required.")
       return
     }
 
@@ -824,7 +806,6 @@ export function CoachDashboard() {
     }
 
     const startAt = `${bulkAssignForm.date}T${bulkAssignForm.startTime}`
-    const endAt = `${bulkAssignForm.date}T${bulkAssignForm.endTime}`
 
     assignSessionToTag(
       bulkAssignForm.tag,
@@ -832,7 +813,6 @@ export function CoachDashboard() {
         title: bulkAssignForm.title,
         type: bulkAssignForm.type,
         startAt,
-        endAt,
         intensity: bulkAssignForm.intensity,
         notes: bulkAssignForm.notes,
       },
@@ -904,9 +884,9 @@ export function CoachDashboard() {
             title: session.title,
             type: session.type,
             startAt: session.startAt,
-            endAt: session.endAt,
             intensity: session.intensity,
             notes: session.notes,
+            ...(session.endAt ? { endAt: session.endAt } : {}),
           },
           {
             focus: session.notes?.split("\n")[0] ?? session.title,
@@ -1110,16 +1090,6 @@ export function CoachDashboard() {
                     value={bulkAssignForm.startTime}
                     onChange={(event) =>
                       setBulkAssignForm((prev) => ({ ...prev, startTime: event.target.value }))
-                    }
-                  />
-                </div>
-                <div>
-                  <label className="text-xs font-medium text-gray-600">End Time *</label>
-                  <Input
-                    type="time"
-                    value={bulkAssignForm.endTime}
-                    onChange={(event) =>
-                      setBulkAssignForm((prev) => ({ ...prev, endTime: event.target.value }))
                     }
                   />
                 </div>
@@ -1405,16 +1375,6 @@ export function CoachDashboard() {
                   value={sessionEditForm.startTime}
                   onChange={(event) =>
                     setSessionEditForm((prev) => ({ ...prev, startTime: event.target.value }))
-                  }
-                />
-              </div>
-              <div>
-                <label className="text-xs font-medium text-gray-600">End Time *</label>
-                <Input
-                  type="time"
-                  value={sessionEditForm.endTime}
-                  onChange={(event) =>
-                    setSessionEditForm((prev) => ({ ...prev, endTime: event.target.value }))
                   }
                 />
               </div>

--- a/src/lib/role-types.ts
+++ b/src/lib/role-types.ts
@@ -73,7 +73,7 @@ export type Session = {
   type: string
   title: string
   startAt: string
-  endAt: string
+  endAt?: string
   intensity: string
   notes?: string
   completed: boolean

--- a/src/lib/state-normalizer.ts
+++ b/src/lib/state-normalizer.ts
@@ -222,7 +222,8 @@ const normalizeSessions = (sessions: unknown): Session[] => {
     const record = session as Record<string, unknown>
     if (!isFiniteNumber(record.id)) continue
     if (!isString(record.type) || !isString(record.title)) continue
-    if (!isString(record.startAt) || !isString(record.endAt) || !isString(record.intensity)) continue
+    if (!isString(record.startAt) || !isString(record.intensity)) continue
+    const hasEndAt = isString(record.endAt)
     const notes = isString(record.notes) ? record.notes : undefined
     const assignedBy = isString(record.assignedBy) ? record.assignedBy : undefined
     const focus = isString(record.focus) ? record.focus : undefined
@@ -232,12 +233,12 @@ const normalizeSessions = (sessions: unknown): Session[] => {
       type: record.type,
       title: record.title,
       startAt: record.startAt,
-      endAt: record.endAt,
       intensity: record.intensity,
       notes,
       completed,
       assignedBy,
       focus,
+      ...(hasEndAt ? { endAt: record.endAt as string } : {}),
     })
   }
   return normalized


### PR DESCRIPTION
## Summary
- make session end times optional in shared types and role context logic so sessions can be scheduled with only a start
- update athlete training and coach dashboard flows to remove end time inputs and gracefully display sessions without an end
- adjust formatters and normalization helpers to handle missing end timestamps across the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6906a619249c8323902410fdcb667550